### PR TITLE
SDK CI tweaks

### DIFF
--- a/.github/workflows/sdk_utils.yml
+++ b/.github/workflows/sdk_utils.yml
@@ -1,4 +1,4 @@
-name: SDK Utils Linux
+name: SDK Utils CI
 on:
   push:
     branches:
@@ -18,7 +18,7 @@ jobs:
       - name: Setup
         run: |
           sudo apt-get install nodejs
-      - name: Run SDK Tests
+      - name: SDK Tests and Lint
         run: |
           set -eExuo pipefail
           cd sdk/ic_vetkd_sdk_utils
@@ -34,7 +34,7 @@ jobs:
       - name: Setup
         run: |
           brew install nodejs
-      - name: Run SDK Tests
+      - name: SDK Tests and Lint
         run: |
           set -eExuo pipefail
           cd sdk/ic_vetkd_sdk_utils

--- a/sdk/ic_vetkd_sdk_utils/test/index.test.ts
+++ b/sdk/ic_vetkd_sdk_utils/test/index.test.ts
@@ -9,7 +9,6 @@ if (typeof window === 'undefined') {
 }
 
 beforeAll(() => {
-    console.log("beforeAll");
     Object.defineProperty(window, 'crypto', {
         value: crypto.webcrypto,
         writable: true,


### PR DESCRIPTION
Remove a debug console.log from the SDK tests

Rename the SDK CI steps to more clearly indicate what they are doing