### PR TITLE
chore: CRP-2724 fix package errors in SDK utils' package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12108,15 +12108,26 @@
         "sdk/ic_vetkd_sdk_utils": {
             "dependencies": {
                 "@noble/curves": "^1.8.1",
-                "@noble/hashes": "^1.7.1",
-                "typescript": "^5.7.3"
+                "@noble/hashes": "^1.7.1"
             },
             "devDependencies": {
                 "@babel/preset-env": "7.26.0",
                 "@babel/preset-typescript": "^7.26.0",
+                "@eslint/js": "^9.22.0",
                 "@jest/globals": "^29.7.0",
                 "jest": "^29.7.0",
+                "typescript": "^5.7.3",
                 "typescript-eslint": "8.24"
+            }
+        },
+        "sdk/ic_vetkd_sdk_utils/node_modules/@eslint/js": {
+            "version": "9.22.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.22.0.tgz",
+            "integrity": "sha512-vLFajx9o8d1/oL2ZkpMYbkLv8nDB6yaIwFNt7nI4+I80U/z03SxmfOMsLbvWr3p7C+Wnoh//aOu2pQW8cS0HCQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         }
     }

--- a/sdk/ic_vetkd_sdk_utils/package.json
+++ b/sdk/ic_vetkd_sdk_utils/package.json
@@ -8,14 +8,15 @@
     "typings": "dist/types/index.d.ts",
     "dependencies": {
         "@noble/curves": "^1.8.1",
-        "@noble/hashes": "^1.7.1",
-        "typescript": "^5.7.3"
+        "@noble/hashes": "^1.7.1"
     },
     "devDependencies": {
         "@babel/preset-env": "7.26.0",
         "@babel/preset-typescript": "^7.26.0",
+        "@eslint/js": "^9.22.0",
         "@jest/globals": "^29.7.0",
         "jest": "^29.7.0",
+        "typescript": "^5.7.3",
         "typescript-eslint": "8.24"
     },
     "scripts": {


### PR DESCRIPTION
Fixes the package errors reported by `npm-check` and downgrades `typescript` to a dev dependency.

Several packages are outdated, but this will be fixed in separate PRs so as not to pollute this PR here.

### Before
```
sdk/ic_vetkd_sdk_utils $ npx npm-check            

typescript          😍  UPDATE!   Your local install is out of date. https://www.typescriptlang.org/
                                 npm install typescript@5.8.2 --save to go from 5.7.3 to 5.8.2

@babel/preset-env   😎  PATCH UP  Patch update available. https://babel.dev/docs/en/next/babel-preset-env
                                 npm install @babel/preset-env@7.26.9 --save-dev to go from 7.26.0 to 7.26.9

typescript-eslint   😎  MINOR UP  Minor update available. https://typescript-eslint.io/packages/typescript-eslint
                                 npm install typescript-eslint@8.26.1 --save-dev to go from 8.24.1 to 8.26.1

@eslint/js          😟  PKG ERR!  Not in the package.json. Found in: /eslint.config.mjs
                    😎  MINOR UP  Minor update available. https://eslint.org
                                 npm install @eslint/js@9.22.0 --save to go from 9.21.0 to 9.22.0

Use npm-check -u for interactive update.
```
### After
* Note that the `PKG ERR!` is gone.
```
sdk/ic_vetkd_sdk_utils $ npx npm-check                      

@babel/preset-env   😎  PATCH UP  Patch update available. https://babel.dev/docs/en/next/babel-preset-env
                                 npm install @babel/preset-env@7.26.9 --save-dev to go from 7.26.0 to 7.26.9

typescript          😍  UPDATE!   Your local install is out of date. https://www.typescriptlang.org/
                                 npm install typescript@5.8.2 --save-dev to go from 5.7.3 to 5.8.2

typescript-eslint   😎  MINOR UP  Minor update available. https://typescript-eslint.io/packages/typescript-eslint
                                 npm install typescript-eslint@8.26.1 --save-dev to go from 8.24.1 to 8.26.1

Use npm-check -u for interactive update.
```
and
```
sdk/ic_vetkd_sdk_utils $ npx depcheck
No depcheck issue
```