### PR TITLE
feat: Export a function for verifying BLS signatures from TS utils

### DIFF
--- a/frontend/ic_vetkeys/src/utils/utils.test.ts
+++ b/frontend/ic_vetkeys/src/utils/utils.test.ts
@@ -8,8 +8,10 @@ import {
     augmentedHashToG1,
     deriveSymmetricKey,
     hashToScalar,
+    verifyBlsSignature,
 } from "./utils";
 import { expect, test } from "vitest";
+import { bls12_381 } from "@noble/curves/bls12-381";
 
 function hexToBytes(hex: string): Uint8Array {
     const bytes = new Uint8Array(hex.length / 2);
@@ -97,6 +99,29 @@ test("augmented hash to G1", () => {
     const calculated = augmentedHashToG1(pk, msg);
 
     assertEqual(bytesToHex(calculated.toRawBytes(true)), expected);
+});
+
+test("BLS signature verification", () => {
+    const pk = DerivedPublicKey.deserialize(
+        hexToBytes(
+            "972c4c6cc184b56121a1d27ef1ca3a2334d1a51be93573bd18e168f78f8fe15ce44fb029ffe8e9c3ee6bea2660f4f35e0774a35a80d6236c050fd8f831475b5e145116d3e83d26c533545f64b08464e4bcc755f990a381efa89804212d4eef5f",
+        ),
+    );
+
+    const msg = new TextEncoder().encode("message");
+
+    const signatureHex = "987db5406ce297e729c8564a106dc896943b00216a095fe9c5d32a16a330c02eb80e6f468ede83cde5462b5145b58f65"
+    // Test verification works passing a hex string
+    assertEqual(verifyBlsSignature(pk, msg, signatureHex), true);
+
+    // Test verification works passing a binary string
+    const signatureBytes = hexToBytes(signatureHex);
+    assertEqual(verifyBlsSignature(pk, msg, signatureBytes), true);
+
+    // Test verification works passing a point objecet
+    const signaturePoint = bls12_381.G1.ProjectivePoint.fromHex(signatureHex);
+    assertEqual(verifyBlsSignature(pk, msg, signaturePoint), true);
+
 });
 
 test("protocol flow with precomputed data", () => {

--- a/frontend/ic_vetkeys/src/utils/utils.test.ts
+++ b/frontend/ic_vetkeys/src/utils/utils.test.ts
@@ -112,9 +112,6 @@ test("BLS signature verification", () => {
     const wrongMsg = new TextEncoder().encode("this is some other message");
 
     const signatureHex = "987db5406ce297e729c8564a106dc896943b00216a095fe9c5d32a16a330c02eb80e6f468ede83cde5462b5145b58f65"
-    // Test verification works passing a hex string
-    assertEqual(verifyBlsSignature(pk, msg, signatureHex), true);
-    assertEqual(verifyBlsSignature(pk, wrongMsg, signatureHex), false);
 
     // Test verification works passing a binary string
     const signatureBytes = hexToBytes(signatureHex);

--- a/frontend/ic_vetkeys/src/utils/utils.test.ts
+++ b/frontend/ic_vetkeys/src/utils/utils.test.ts
@@ -109,19 +109,22 @@ test("BLS signature verification", () => {
     );
 
     const msg = new TextEncoder().encode("message");
+    const wrongMsg = new TextEncoder().encode("this is some other message");
 
     const signatureHex = "987db5406ce297e729c8564a106dc896943b00216a095fe9c5d32a16a330c02eb80e6f468ede83cde5462b5145b58f65"
     // Test verification works passing a hex string
     assertEqual(verifyBlsSignature(pk, msg, signatureHex), true);
+    assertEqual(verifyBlsSignature(pk, wrongMsg, signatureHex), false);
 
     // Test verification works passing a binary string
     const signatureBytes = hexToBytes(signatureHex);
     assertEqual(verifyBlsSignature(pk, msg, signatureBytes), true);
+    assertEqual(verifyBlsSignature(pk, wrongMsg, signatureBytes), false);
 
     // Test verification works passing a point objecet
     const signaturePoint = bls12_381.G1.ProjectivePoint.fromHex(signatureHex);
     assertEqual(verifyBlsSignature(pk, msg, signaturePoint), true);
-
+    assertEqual(verifyBlsSignature(pk, wrongMsg, signaturePoint), false);
 });
 
 test("protocol flow with precomputed data", () => {

--- a/frontend/ic_vetkeys/src/utils/utils.test.ts
+++ b/frontend/ic_vetkeys/src/utils/utils.test.ts
@@ -111,7 +111,8 @@ test("BLS signature verification", () => {
     const msg = new TextEncoder().encode("message");
     const wrongMsg = new TextEncoder().encode("this is some other message");
 
-    const signatureHex = "987db5406ce297e729c8564a106dc896943b00216a095fe9c5d32a16a330c02eb80e6f468ede83cde5462b5145b58f65"
+    const signatureHex =
+        "987db5406ce297e729c8564a106dc896943b00216a095fe9c5d32a16a330c02eb80e6f468ede83cde5462b5145b58f65";
 
     // Test verification works passing a binary string
     const signatureBytes = hexToBytes(signatureHex);

--- a/frontend/ic_vetkeys/src/utils/utils.ts
+++ b/frontend/ic_vetkeys/src/utils/utils.ts
@@ -320,14 +320,16 @@ export function augmentedHashToG1(
 export function verifyBlsSignature(
     pk: DerivedPublicKey,
     message: Uint8Array,
-    signature: G1Point,
+    signature: G1Point | Uint8Array,
 ): boolean {
     const neg_g2 = bls12_381.G2.ProjectivePoint.BASE.negate();
     const gt_one = bls12_381.fields.Fp12.ONE;
 
+    const signaturePt = signature instanceof bls12_381.G1.ProjectivePoint ? signature : bls12_381.G1.ProjectivePoint.fromHex(signature);
+
     const messageG1 = augmentedHashToG1(pk, message);
     const check = bls12_381.pairingBatch([
-        { g1: signature, g2: neg_g2 },
+        { g1: signaturePt, g2: neg_g2 },
         { g1: messageG1, g2: pk.getPoint() },
     ]);
 

--- a/frontend/ic_vetkeys/src/utils/utils.ts
+++ b/frontend/ic_vetkeys/src/utils/utils.ts
@@ -326,7 +326,10 @@ export function verifyBlsSignature(
     const neg_g2 = bls12_381.G2.ProjectivePoint.BASE.negate();
     const gt_one = bls12_381.fields.Fp12.ONE;
 
-    const signaturePt = signature instanceof bls12_381.G1.ProjectivePoint ? signature : bls12_381.G1.ProjectivePoint.fromHex(signature);
+    const signaturePt =
+        signature instanceof bls12_381.G1.ProjectivePoint
+            ? signature
+            : bls12_381.G1.ProjectivePoint.fromHex(signature);
 
     const messageG1 = augmentedHashToG1(pk, message);
     const check = bls12_381.pairingBatch([

--- a/frontend/ic_vetkeys/src/utils/utils.ts
+++ b/frontend/ic_vetkeys/src/utils/utils.ts
@@ -313,9 +313,10 @@ export function augmentedHashToG1(
  * provided BLS signature is the valid one for the provided public key and
  * message.
  *
- * When a VetKey struct is created (VetKey.decryptAndVerify) the signature (aka
- * vetkey) is already verified, so using this function is only necessary when
- * using a vetkey as a VRF or for threshold BLS signatures.
+ * When a VetKey struct is created (using EncryptedVetKey.decryptAndVerify) the signature
+ * is already verified, so using this function is only necessary when
+ * using a vetKey as a VRF or for threshold BLS signatures, with the bytes obtained
+ * from VetKey.signatureBytes.
  */
 export function verifyBlsSignature(
     pk: DerivedPublicKey,
@@ -596,7 +597,7 @@ export class EncryptedVetKey {
             throw new Error("Invalid VetKey");
         }
 
-        // Compute the purported vetkey k
+        // Compute the purported vetKey k
         const c1_tsk = this.#c1.multiply(
             bls12_381.G1.normPrivateKeyToScalar(tsk.getSecretKey()),
         );


### PR DESCRIPTION
Makes life a little easier for end users who might want to for example verify a VRF output