### PR TITLE
chore: CRP-2816 add key initialization

### DIFF
--- a/.github/workflows/backend-motoko.yml
+++ b/.github/workflows/backend-motoko.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - backend/mo/**
+      - backend/rs/canisters/**
       - Cargo.toml
       - Cargo.lock
       - .github/workflows/provision-linux.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "serde_with",
  "sha2 0.10.9",
  "sha3",

--- a/backend/mo/canisters/ic_vetkeys_manager_canister/src/Main.mo
+++ b/backend/mo/canisters/ic_vetkeys_manager_canister/src/Main.mo
@@ -1,4 +1,4 @@
-import { KeyManager } "../../../ic_vetkeys/src";
+import IcVetkeys "../../../ic_vetkeys/src";
 import Types "../../../ic_vetkeys/src/Types";
 import Principal "mo:base/Principal";
 import Text "mo:base/Text";
@@ -6,8 +6,8 @@ import Blob "mo:base/Blob";
 import Result "mo:base/Result";
 import Array "mo:base/Array";
 
-actor {
-    var keyManager = KeyManager.KeyManager<Types.AccessRights>("key_manager", Types.accessRightsOperations());
+actor class (keyName : Text) {
+    var keyManager = IcVetkeys.KeyManager.KeyManager<Types.AccessRights>({ curve = #bls12_381_g2; name = keyName }, "key manager", Types.accessRightsOperations());
     /// In this canister, we use the `ByteBuf` type to represent blobs. The reason is that we want to be consistent with the Rust canister implementation.
     /// Unfortunately, the `Blob` type cannot be serialized/deserialized in the current Rust implementation efficiently without nesting it in another type.
     public type ByteBuf = { inner : Blob };

--- a/backend/mo/ic_vetkeys/src/encrypted_maps/EncryptedMaps.mo
+++ b/backend/mo/ic_vetkeys/src/encrypted_maps/EncryptedMaps.mo
@@ -54,8 +54,8 @@ module {
         return OrderedMap.Make<MapId>(compareMapIds);
     };
 
-    public class EncryptedMaps<T>(domainSeparator : Text, accessRightsOperations : Types.AccessControlOperations<T>) {
-        public var keyManager = KeyManager.KeyManager<T>(domainSeparator, accessRightsOperations);
+    public class EncryptedMaps<T>(key_id : { curve : { #bls12_381_g2 }; name : Text }, domainSeparator : Text, accessRightsOperations : Types.AccessControlOperations<T>) {
+        public var keyManager = KeyManager.KeyManager<T>(key_id, domainSeparator, accessRightsOperations);
         public var mapKeyVals : OrderedMap.Map<(MapId, MapKey), EncryptedMapValue> = mapKeyValsMapOps().empty();
         public var mapKeys : OrderedMap.Map<MapId, [MapKey]> = mapKeysMapOps().empty();
 

--- a/backend/mo/ic_vetkeys/src/key_manager/KeyManager.mo
+++ b/backend/mo/ic_vetkeys/src/key_manager/KeyManager.mo
@@ -49,7 +49,7 @@ module {
     };
 
     // KeyManager class
-    public class KeyManager<T>(domainSeparator : Text, accessRightsOperations : Types.AccessControlOperations<T>) {
+    public class KeyManager<T>(key_id : { curve : { #bls12_381_g2 }; name : Text }, domainSeparator : Text, accessRightsOperations : Types.AccessControlOperations<T>) {
         public var accessControl : OrderedMap.Map<Principal, [(KeyId, T)]> = accessControlMapOps().empty();
         public var sharedKeys : OrderedMap.Map<KeyId, [Principal]> = sharedKeysMapOps().empty();
         let domainSeparatorBytes = Text.encodeUtf8(domainSeparator);
@@ -103,7 +103,7 @@ module {
             let request = {
                 canister_id = null;
                 context;
-                key_id = bls12_381TestKey1();
+                key_id;
             };
 
             let (reply) = await (actor ("aaaaa-aa") : VetkdSystemApi).vetkd_public_key(request);
@@ -127,7 +127,7 @@ module {
                     let request = {
                         input = Blob.fromArray(input);
                         context;
-                        key_id = bls12_381TestKey1();
+                        key_id;
                         transport_public_key = transportKey;
                     };
 
@@ -338,10 +338,5 @@ module {
                 };
             };
         };
-    };
-
-    // Helper function for BLS12-381 test key
-    func bls12_381TestKey1() : { curve : { #bls12_381_g2 }; name : Text } {
-        { curve = #bls12_381_g2; name = "dfx_test_key" };
     };
 };

--- a/backend/mo/ic_vetkeys/test/EncryptedMaps.test.mo
+++ b/backend/mo/ic_vetkeys/test/EncryptedMaps.test.mo
@@ -9,7 +9,7 @@ import { test } "mo:test";
 type EncryptedMaps = VetKey.EncryptedMaps.EncryptedMaps<VetKey.AccessRights>;
 let accessRightsOperations = VetKey.accessRightsOperations();
 func newEncryptedMaps() : EncryptedMaps {
-    EncryptedMaps.EncryptedMaps<VetKey.AccessRights>("encrypted maps", accessRightsOperations);
+    EncryptedMaps.EncryptedMaps<VetKey.AccessRights>({ curve = #bls12_381_g2; name = "dfx_test_key" }, "encrypted maps", accessRightsOperations);
 };
 
 let p1 = Principal.fromText("2vxsx-fae");

--- a/backend/mo/ic_vetkeys/test/KeyManager.test.mo
+++ b/backend/mo/ic_vetkeys/test/KeyManager.test.mo
@@ -10,7 +10,7 @@ let p2 = Principal.fromText("aaaaa-aa");
 let keyName = Text.encodeUtf8("some key");
 
 func newKeyManager() : VetKey.KeyManager.KeyManager<VetKey.AccessRights> {
-    VetKey.KeyManager.KeyManager<VetKey.AccessRights>("key manager", accessRightsOperations);
+    VetKey.KeyManager.KeyManager<VetKey.AccessRights>({ curve = #bls12_381_g2; name = "dfx_test_key" }, "key manager", accessRightsOperations);
 };
 
 test(

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/ic_vetkeys_encrypted_maps_canister.did
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/ic_vetkeys_encrypted_maps_canister.did
@@ -15,7 +15,7 @@ type Result_3 = variant {
 };
 type Result_4 = variant { Ok : opt AccessRights; Err : text };
 type Result_5 = variant { Ok : vec ByteBuf; Err : text };
-service : {
+service : (text) -> {
   get_accessible_shared_map_names : () -> (
       vec record { principal; ByteBuf },
     ) query;

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/tests/tests.rs
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/tests/tests.rs
@@ -174,7 +174,12 @@ impl TestEnvironment {
         pic.add_cycles(example_canister_id, 2_000_000_000_000);
 
         let example_wasm_bytes = load_key_manager_example_canister_wasm();
-        pic.install_canister(example_canister_id, example_wasm_bytes, vec![], None);
+        pic.install_canister(
+            example_canister_id,
+            example_wasm_bytes,
+            encode_one("dfx_test_key").unwrap(),
+            None,
+        );
 
         // Make sure the canister is properly initialized
         fast_forward(&pic, 5);

--- a/backend/rs/canisters/ic_vetkeys_manager_canister/ic_vetkeys_manager_canister.did
+++ b/backend/rs/canisters/ic_vetkeys_manager_canister/ic_vetkeys_manager_canister.did
@@ -6,7 +6,7 @@ type Result_1 = variant {
   Err : text;
 };
 type Result_2 = variant { Ok : opt AccessRights; Err : text };
-service : {
+service : (text) -> {
   get_accessible_shared_key_ids : () -> (
       vec record { principal; ByteBuf },
     ) query;

--- a/backend/rs/canisters/ic_vetkeys_manager_canister/src/lib.rs
+++ b/backend/rs/canisters/ic_vetkeys_manager_canister/src/lib.rs
@@ -1,25 +1,46 @@
 use std::cell::RefCell;
 
 use candid::Principal;
-use ic_cdk::{query, update};
+use ic_cdk::{init, query, update};
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::storable::Blob;
 use ic_stable_structures::DefaultMemoryImpl;
 use ic_vetkeys::key_manager::{KeyManager, VetKey, VetKeyVerificationKey};
 use ic_vetkeys::types::{AccessRights, ByteBuf, TransportKey};
+use ic_vetkeys::vetkd_api_types::{VetKDCurve, VetKDKeyId};
 
 type Memory = VirtualMemory<DefaultMemoryImpl>;
 
 thread_local! {
     static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
-    static KEY_MANAGER: RefCell<KeyManager<AccessRights>> = RefCell::new(KeyManager::init("key_manager", id_to_memory(0), id_to_memory(1), id_to_memory(2)));
+    static KEY_MANAGER: RefCell<Option<KeyManager<AccessRights>>> =
+        const { RefCell::new(None) };
+}
+
+#[init]
+fn init(key_name: String) {
+    let key_id = VetKDKeyId {
+        curve: VetKDCurve::Bls12_381_G2,
+        name: key_name,
+    };
+    KEY_MANAGER.with_borrow_mut(|km| {
+        km.replace(KeyManager::init(
+            "key_manager_dapp",
+            key_id,
+            id_to_memory(0),
+            id_to_memory(1),
+            id_to_memory(2),
+        ))
+    });
 }
 
 #[query]
 fn get_accessible_shared_key_ids() -> Vec<(Principal, ByteBuf)> {
     KEY_MANAGER.with_borrow(|km| {
-        km.get_accessible_shared_key_ids(ic_cdk::caller())
+        km.as_ref()
+            .unwrap()
+            .get_accessible_shared_key_ids(ic_cdk::caller())
             .into_iter()
             .map(|key_id| (key_id.0, ByteBuf::from(key_id.1.as_ref().to_vec())))
             .collect()
@@ -33,13 +54,17 @@ fn get_shared_user_access_for_key(
 ) -> Result<Vec<(Principal, AccessRights)>, String> {
     let key_name = bytebuf_to_blob(key_name)?;
     let key_id = (key_owner, key_name);
-    KEY_MANAGER.with_borrow(|km| km.get_shared_user_access_for_key(ic_cdk::caller(), key_id))
+    KEY_MANAGER.with_borrow(|km| {
+        km.as_ref()
+            .unwrap()
+            .get_shared_user_access_for_key(ic_cdk::caller(), key_id)
+    })
 }
 
 #[update]
 async fn get_vetkey_verification_key() -> VetKeyVerificationKey {
     KEY_MANAGER
-        .with_borrow(|km| km.get_vetkey_verification_key())
+        .with_borrow(|km| km.as_ref().unwrap().get_vetkey_verification_key())
         .await
 }
 
@@ -52,7 +77,11 @@ async fn get_encrypted_vetkey(
     let key_name = bytebuf_to_blob(key_name)?;
     let key_id = (key_owner, key_name);
     Ok(KEY_MANAGER
-        .with_borrow(|km| km.get_encrypted_vetkey(ic_cdk::caller(), key_id, transport_key))?
+        .with_borrow(|km| {
+            km.as_ref()
+                .unwrap()
+                .get_encrypted_vetkey(ic_cdk::caller(), key_id, transport_key)
+        })?
         .await)
 }
 
@@ -64,7 +93,11 @@ fn get_user_rights(
 ) -> Result<Option<AccessRights>, String> {
     let key_name = bytebuf_to_blob(key_name)?;
     let key_id = (key_owner, key_name);
-    KEY_MANAGER.with_borrow(|km| km.get_user_rights(ic_cdk::caller(), key_id, user))
+    KEY_MANAGER.with_borrow(|km| {
+        km.as_ref()
+            .unwrap()
+            .get_user_rights(ic_cdk::caller(), key_id, user)
+    })
 }
 
 #[update]
@@ -76,8 +109,11 @@ fn set_user_rights(
 ) -> Result<Option<AccessRights>, String> {
     let key_name = bytebuf_to_blob(key_name)?;
     let key_id = (key_owner, key_name);
-    KEY_MANAGER
-        .with_borrow_mut(|km| km.set_user_rights(ic_cdk::caller(), key_id, user, access_rights))
+    KEY_MANAGER.with_borrow_mut(|km| {
+        km.as_mut()
+            .unwrap()
+            .set_user_rights(ic_cdk::caller(), key_id, user, access_rights)
+    })
 }
 
 #[update]
@@ -88,7 +124,11 @@ fn remove_user(
 ) -> Result<Option<AccessRights>, String> {
     let key_name = bytebuf_to_blob(key_name)?;
     let key_id = (key_owner, key_name);
-    KEY_MANAGER.with_borrow_mut(|km| km.remove_user(ic_cdk::caller(), key_id, user))
+    KEY_MANAGER.with_borrow_mut(|km| {
+        km.as_mut()
+            .unwrap()
+            .remove_user(ic_cdk::caller(), key_id, user)
+    })
 }
 
 fn bytebuf_to_blob(buf: ByteBuf) -> Result<Blob<32>, String> {

--- a/backend/rs/canisters/ic_vetkeys_manager_canister/tests/tests.rs
+++ b/backend/rs/canisters/ic_vetkeys_manager_canister/tests/tests.rs
@@ -187,7 +187,12 @@ impl TestEnvironment {
         pic.add_cycles(example_canister_id, 2_000_000_000_000);
 
         let example_wasm_bytes = load_key_manager_example_canister_wasm();
-        pic.install_canister(example_canister_id, example_wasm_bytes, vec![], None);
+        pic.install_canister(
+            example_canister_id,
+            example_wasm_bytes,
+            encode_one("dfx_test_key").unwrap(),
+            None,
+        );
 
         // Make sure the canister is properly initialized
         fast_forward(&pic, 5);

--- a/backend/rs/ic_vetkeys/Cargo.toml
+++ b/backend/rs/ic_vetkeys/Cargo.toml
@@ -32,6 +32,7 @@ rand = { workspace = true }
 rand_chacha = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
+serde_cbor = { workspace = true }
 serde_with = { workspace = true }
 sha2 = "0.10.9"
 sha3 = "0.10.8"

--- a/backend/rs/ic_vetkeys/src/lib.rs
+++ b/backend/rs/ic_vetkeys/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../README.md")]
-
 #![warn(future_incompatible)]
 
 pub mod encrypted_maps;

--- a/backend/rs/ic_vetkeys/src/types.rs
+++ b/backend/rs/ic_vetkeys/src/types.rs
@@ -15,6 +15,24 @@ pub type MapKey = Blob<32>;
 pub type TransportKey = ByteBuf;
 pub type EncryptedMapValue = ByteBuf;
 
+#[derive(Serialize, Deserialize)]
+pub struct KeyManagerConfig {
+    pub domain_separator: String,
+    pub key_id: crate::vetkd_api_types::VetKDKeyId,
+}
+
+impl Storable for KeyManagerConfig {
+    fn to_bytes(&self) -> Cow<[u8]> {
+        Cow::Owned(serde_cbor::to_vec(self).unwrap())
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        serde_cbor::from_slice(bytes.as_ref()).unwrap()
+    }
+
+    const BOUND: Bound = Bound::Unbounded;
+}
+
 /// Access rights of a user to a vetKey in [`crate::key_manager::KeyManager`] and/or an encrypted map in [`crate::encrypted_maps::EncryptedMaps`].
 #[repr(u8)]
 #[derive(

--- a/backend/rs/ic_vetkeys/src/vetkd_api_types.rs
+++ b/backend/rs/ic_vetkeys/src/vetkd_api_types.rs
@@ -1,15 +1,15 @@
 use candid::CandidType;
-use candid::Deserialize;
 use ic_cdk::api::management_canister::main::CanisterId;
+use serde::{Deserialize, Serialize};
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
 pub enum VetKDCurve {
     #[serde(rename = "bls12_381_g2")]
     #[allow(non_camel_case_types)]
     Bls12_381_G2,
 }
 
-#[derive(CandidType, Deserialize, Clone, Debug)]
+#[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
 pub struct VetKDKeyId {
     pub curve: VetKDCurve,
     pub name: String,

--- a/backend/rs/ic_vetkeys/tests/encrypted_maps.rs
+++ b/backend/rs/ic_vetkeys/tests/encrypted_maps.rs
@@ -15,8 +15,11 @@ use ic_vetkeys_test_utils::{
 use rand::{CryptoRng, Rng};
 use strum::IntoEnumIterator;
 
-use ic_vetkeys::encrypted_maps::EncryptedMaps;
 use ic_vetkeys::types::{AccessControl, AccessRights};
+use ic_vetkeys::{
+    encrypted_maps::EncryptedMaps,
+    vetkd_api_types::{VetKDCurve, VetKDKeyId},
+};
 
 #[test]
 fn can_init_memory() {
@@ -501,9 +504,17 @@ fn random_encrypted_maps<R: Rng + CryptoRng>(rng: &mut R) -> EncryptedMaps<Acces
     let domain_separator_len = rng.gen_range(0..32);
     EncryptedMaps::init(
         &random_utf8_string(rng, domain_separator_len),
+        bls12_381_dfx_test_key(),
         memory_manager.get(MemoryId::new(memory_id_encrypted_maps)),
         memory_manager.get(MemoryId::new(memory_ids_key_manager[0])),
         memory_manager.get(MemoryId::new(memory_ids_key_manager[1])),
         memory_manager.get(MemoryId::new(memory_ids_key_manager[2])),
     )
+}
+
+fn bls12_381_dfx_test_key() -> VetKDKeyId {
+    VetKDKeyId {
+        curve: VetKDCurve::Bls12_381_G2,
+        name: "dfx_test_key".to_string(),
+    }
 }

--- a/backend/rs/ic_vetkeys/tests/key_manager.rs
+++ b/backend/rs/ic_vetkeys/tests/key_manager.rs
@@ -5,8 +5,11 @@ use ic_stable_structures::{
     memory_manager::{MemoryId, MemoryManager},
     DefaultMemoryImpl,
 };
-use ic_vetkeys::key_manager::KeyManager;
 use ic_vetkeys::types::AccessRights;
+use ic_vetkeys::{
+    key_manager::KeyManager,
+    vetkd_api_types::{VetKDCurve, VetKDKeyId},
+};
 use ic_vetkeys_test_utils::{
     random_access_rights, random_name, random_self_authenticating_principal,
     random_unique_memory_ids, random_utf8_string, reproducible_rng,
@@ -244,12 +247,14 @@ fn can_instantiate_two_key_managers() {
     let memory_manager = MemoryManager::init(DefaultMemoryImpl::default());
     let key_manager_1 = KeyManager::<AccessRights>::init(
         "key_manager_1",
+        bls12_381_dfx_test_key(),
         memory_manager.get(MemoryId::new(0)),
         memory_manager.get(MemoryId::new(1)),
         memory_manager.get(MemoryId::new(2)),
     );
     let key_manager_2 = KeyManager::<AccessRights>::init(
         "key_manager_2",
+        bls12_381_dfx_test_key(),
         memory_manager.get(MemoryId::new(3)),
         memory_manager.get(MemoryId::new(4)),
         memory_manager.get(MemoryId::new(5)),
@@ -264,8 +269,16 @@ fn random_key_manager<R: Rng + CryptoRng>(rng: &mut R) -> KeyManager<AccessRight
     let domain_separator_len = rng.gen_range(0..32);
     KeyManager::<AccessRights>::init(
         &random_utf8_string(rng, domain_separator_len),
+        bls12_381_dfx_test_key(),
         memory_manager.get(MemoryId::new(memory_ids_key_manager[0])),
         memory_manager.get(MemoryId::new(memory_ids_key_manager[1])),
         memory_manager.get(MemoryId::new(memory_ids_key_manager[2])),
     )
+}
+
+fn bls12_381_dfx_test_key() -> VetKDKeyId {
+    VetKDKeyId {
+        curve: VetKDCurve::Bls12_381_G2,
+        name: "dfx_test_key".to_string(),
+    }
 }

--- a/examples/basic_ibe/backend/backend.did
+++ b/examples/basic_ibe/backend/backend.did
@@ -9,7 +9,7 @@ type SendMessageRequest = record {
   encrypted_message : blob;
   receiver : principal;
 };
-service : {
+service : (text) -> {
   get_my_encrypted_ibe_key : (blob) -> (blob);
   get_my_messages : () -> (Inbox) query;
   get_root_ibe_public_key : () -> (blob);

--- a/examples/basic_ibe/deploy_locally.sh
+++ b/examples/basic_ibe/deploy_locally.sh
@@ -14,6 +14,7 @@ dfx deps pull && dfx deps init && dfx deps deploy &&
     export CANISTER_ID_INTERNET_IDENTITY=rdmx6-jaaaa-aaaaa-aaadq-cai
 
 dfx canister create basic_ibe
+dfx deploy --argument '("dfx_test_key")' basic_ibe
 
 # Store environment variables for the frontend.
 echo "DFX_NETWORK=$DFX_NETWORK" > frontend/.env

--- a/examples/basic_ibe/src/declarations/basic_ibe/basic_ibe.did
+++ b/examples/basic_ibe/src/declarations/basic_ibe/basic_ibe.did
@@ -9,7 +9,7 @@ type SendMessageRequest = record {
   encrypted_message : blob;
   receiver : principal;
 };
-service : {
+service : (text) -> {
   get_my_encrypted_ibe_key : (blob) -> (blob);
   get_my_messages : () -> (Inbox) query;
   get_root_ibe_public_key : () -> (blob);

--- a/examples/basic_ibe/src/declarations/basic_ibe/basic_ibe.did.js
+++ b/examples/basic_ibe/src/declarations/basic_ibe/basic_ibe.did.js
@@ -22,4 +22,4 @@ export const idlFactory = ({ IDL }) => {
     'send_message' : IDL.Func([SendMessageRequest], [Result], []),
   });
 };
-export const init = ({ IDL }) => { return []; };
+export const init = ({ IDL }) => { return [IDL.Text]; };

--- a/examples/basic_timelock_ibe/backend/backend.did
+++ b/examples/basic_timelock_ibe/backend/backend.did
@@ -18,7 +18,7 @@ type OpenLotsResponse = record {
 };
 type Result = variant { Ok : nat; Err : text };
 type Result_1 = variant { Ok; Err : text };
-service : () -> {
+service : (text) -> {
   create_lot : (text, text, nat16) -> (Result);
   get_lots : () -> (OpenLotsResponse, ClosedLotsResponse) query;
   get_root_ibe_public_key : () -> (blob);

--- a/examples/basic_timelock_ibe/deploy_locally.sh
+++ b/examples/basic_timelock_ibe/deploy_locally.sh
@@ -14,6 +14,7 @@ dfx deps pull && dfx deps init && dfx deps deploy &&
     export CANISTER_ID_INTERNET_IDENTITY=rdmx6-jaaaa-aaaaa-aaadq-cai
 
 dfx canister create basic_timelock_ibe
+dfx deploy --argument '("dfx_test_key")' basic_timelock_ibe
 
 # Store environment variables for the frontend.
 echo "DFX_NETWORK=$DFX_NETWORK" > frontend/.env

--- a/examples/basic_timelock_ibe/src/declarations/basic_timelock_ibe/basic_timelock_ibe.did
+++ b/examples/basic_timelock_ibe/src/declarations/basic_timelock_ibe/basic_timelock_ibe.did
@@ -18,7 +18,7 @@ type OpenLotsResponse = record {
 };
 type Result = variant { Ok : nat; Err : text };
 type Result_1 = variant { Ok; Err : text };
-service : () -> {
+service : (text) -> {
   create_lot : (text, text, nat16) -> (Result);
   get_lots : () -> (OpenLotsResponse, ClosedLotsResponse) query;
   get_root_ibe_public_key : () -> (blob);

--- a/examples/basic_timelock_ibe/src/declarations/basic_timelock_ibe/basic_timelock_ibe.did.js
+++ b/examples/basic_timelock_ibe/src/declarations/basic_timelock_ibe/basic_timelock_ibe.did.js
@@ -35,4 +35,4 @@ export const idlFactory = ({ IDL }) => {
     'start_with_interval_secs' : IDL.Func([IDL.Nat64], [], []),
   });
 };
-export const init = ({ IDL }) => { return []; };
+export const init = ({ IDL }) => { return [IDL.Text]; };

--- a/examples/password_manager/deploy_locally.sh
+++ b/examples/password_manager/deploy_locally.sh
@@ -15,7 +15,7 @@ dfx deps pull && dfx deps init && dfx deps deploy &&
 
 # Deploy the backend canister.
 pushd ../../backend/rs/canisters/ic_vetkeys_encrypted_maps_canister
-    dfx deploy
+    dfx deploy --argument '("dfx_test_key")' ic_vetkeys_encrypted_maps_canister
     export CANISTER_ID_IC_VETKEYS_ENCRYPTED_MAPS_CANISTER=$(dfx canister id ic_vetkeys_encrypted_maps_canister)
 popd
 

--- a/examples/password_manager_with_metadata/backend/backend.did
+++ b/examples/password_manager_with_metadata/backend/backend.did
@@ -22,7 +22,7 @@ type Result_4 = variant {
   Ok : opt record { ByteBuf; PasswordMetadata };
   Err : text;
 };
-service : {
+service : (text) -> {
   get_accessible_shared_map_names : () -> (
       vec record { principal; ByteBuf },
     ) query;

--- a/examples/password_manager_with_metadata/backend/src/lib.rs
+++ b/examples/password_manager_with_metadata/backend/src/lib.rs
@@ -1,11 +1,12 @@
 use candid::{CandidType, Principal};
-use ic_cdk::{query, update};
+use ic_cdk::{init, query, update};
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::storable::Blob;
 use ic_stable_structures::{storable::Bound, Storable};
 use ic_stable_structures::{BTreeMap as StableBTreeMap, DefaultMemoryImpl};
 use ic_vetkeys::encrypted_maps::{EncryptedMaps, VetKey, VetKeyVerificationKey};
 use ic_vetkeys::types::{AccessRights, ByteBuf, EncryptedMapValue, TransportKey};
+use ic_vetkeys::vetkd_api_types::{VetKDCurve, VetKDKeyId};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::cell::RefCell;
@@ -69,22 +70,37 @@ type StableMetadataMap = StableBTreeMap<(MapOwner, MapName, MapKey), PasswordMet
 thread_local! {
     static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
         RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
-    static ENCRYPTED_MAPS: RefCell<EncryptedMaps<AccessRights>> = RefCell::new(EncryptedMaps::init(
-        "password_manager",
-        MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(0))),
-        MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(1))),
-        MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(2))),
-        MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(3))),
-    ));
+    static ENCRYPTED_MAPS: RefCell<Option<EncryptedMaps<AccessRights>>> =
+        const { RefCell::new(None) };
     static METADATA: RefCell<StableMetadataMap> = RefCell::new(StableBTreeMap::new(
         MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(4))),
     ));
+}
+
+#[init]
+fn init(key_name: String) {
+    let key_id = VetKDKeyId {
+        curve: VetKDCurve::Bls12_381_G2,
+        name: key_name,
+    };
+    ENCRYPTED_MAPS.with_borrow_mut(|encrypted_maps| {
+        encrypted_maps.replace(EncryptedMaps::init(
+            "password_manager_dapp",
+            key_id,
+            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(0))),
+            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(1))),
+            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(2))),
+            MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(3))),
+        ))
+    });
 }
 
 #[query]
 fn get_accessible_shared_map_names() -> Vec<(Principal, ByteBuf)> {
     ENCRYPTED_MAPS.with_borrow(|encrypted_maps| {
         encrypted_maps
+            .as_ref()
+            .unwrap()
             .get_accessible_shared_map_names(ic_cdk::caller())
             .into_iter()
             .map(|map_id| (map_id.0, ByteBuf::from(map_id.1.as_ref().to_vec())))
@@ -102,8 +118,12 @@ fn get_shared_user_access_for_map(
         map_owner,
         Blob::try_from(map_name.as_ref()).map_err(|_e| "name too long")?,
     );
-    ENCRYPTED_MAPS
-        .with_borrow(|encrypted_maps| encrypted_maps.get_shared_user_access_for_map(caller, key_id))
+    ENCRYPTED_MAPS.with_borrow(|encrypted_maps| {
+        encrypted_maps
+            .as_ref()
+            .unwrap()
+            .get_shared_user_access_for_map(caller, key_id)
+    })
 }
 
 #[query]
@@ -114,7 +134,10 @@ fn get_encrypted_values_for_map_with_metadata(
     let map_name = bytebuf_to_blob(map_name)?;
     let map_id = (map_owner, map_name);
     let encrypted_values_result = ENCRYPTED_MAPS.with_borrow(|encrypted_maps| {
-        encrypted_maps.get_encrypted_values_for_map(ic_cdk::caller(), map_id)
+        encrypted_maps
+            .as_ref()
+            .unwrap()
+            .get_encrypted_values_for_map(ic_cdk::caller(), map_id)
     });
     encrypted_values_result.map(|map_values| {
         METADATA.with_borrow(|metadata| {
@@ -142,6 +165,8 @@ fn get_encrypted_values_for_map_with_metadata(
 fn get_owned_non_empty_map_names() -> Vec<ByteBuf> {
     ENCRYPTED_MAPS.with_borrow(|encrypted_maps| {
         encrypted_maps
+            .as_ref()
+            .unwrap()
             .get_owned_non_empty_map_names(ic_cdk::caller())
             .into_iter()
             .map(|map_name| ByteBuf::from(map_name.as_slice().to_vec()))
@@ -164,6 +189,8 @@ fn insert_encrypted_value_with_metadata(
     let map_key = bytebuf_to_blob(map_key)?;
     ENCRYPTED_MAPS.with_borrow_mut(|encrypted_maps| {
         encrypted_maps
+            .as_mut()
+            .unwrap()
             .insert_encrypted_value(caller, map_id, map_key, value)
             .map(|opt_prev_value| {
                 METADATA.with_borrow_mut(|metadata| {
@@ -189,6 +216,8 @@ fn remove_encrypted_value_with_metadata(
     let map_key = bytebuf_to_blob(map_key)?;
     ENCRYPTED_MAPS.with_borrow_mut(|encrypted_maps| {
         encrypted_maps
+            .as_mut()
+            .unwrap()
             .remove_encrypted_value(ic_cdk::caller(), map_id, map_key)
             .map(|opt_prev_value| {
                 METADATA.with_borrow_mut(|metadata| {
@@ -202,7 +231,12 @@ fn remove_encrypted_value_with_metadata(
 #[update]
 async fn get_vetkey_verification_key() -> VetKeyVerificationKey {
     ENCRYPTED_MAPS
-        .with_borrow(|encrypted_maps| encrypted_maps.get_vetkey_verification_key())
+        .with_borrow(|encrypted_maps| {
+            encrypted_maps
+                .as_ref()
+                .unwrap()
+                .get_vetkey_verification_key()
+        })
         .await
 }
 
@@ -216,7 +250,11 @@ async fn get_encrypted_vetkey(
     let map_id = (map_owner, map_name);
     Ok(ENCRYPTED_MAPS
         .with_borrow(|encrypted_maps| {
-            encrypted_maps.get_encrypted_vetkey(ic_cdk::caller(), map_id, transport_key)
+            encrypted_maps.as_ref().unwrap().get_encrypted_vetkey(
+                ic_cdk::caller(),
+                map_id,
+                transport_key,
+            )
         })?
         .await)
 }
@@ -230,7 +268,10 @@ fn get_user_rights(
     let map_name = bytebuf_to_blob(map_name)?;
     let map_id = (map_owner, map_name);
     ENCRYPTED_MAPS.with_borrow(|encrypted_maps| {
-        encrypted_maps.get_user_rights(ic_cdk::caller(), map_id, user)
+        encrypted_maps
+            .as_ref()
+            .unwrap()
+            .get_user_rights(ic_cdk::caller(), map_id, user)
     })
 }
 
@@ -244,7 +285,12 @@ fn set_user_rights(
     let map_name = bytebuf_to_blob(map_name)?;
     let map_id = (map_owner, map_name);
     ENCRYPTED_MAPS.with_borrow_mut(|encrypted_maps| {
-        encrypted_maps.set_user_rights(ic_cdk::caller(), map_id, user, access_rights)
+        encrypted_maps.as_mut().unwrap().set_user_rights(
+            ic_cdk::caller(),
+            map_id,
+            user,
+            access_rights,
+        )
     })
 }
 
@@ -257,7 +303,10 @@ fn remove_user(
     let map_name = bytebuf_to_blob(map_name)?;
     let map_id = (map_owner, map_name);
     ENCRYPTED_MAPS.with_borrow_mut(|encrypted_maps| {
-        encrypted_maps.remove_user(ic_cdk::caller(), map_id, user)
+        encrypted_maps
+            .as_mut()
+            .unwrap()
+            .remove_user(ic_cdk::caller(), map_id, user)
     })
 }
 

--- a/examples/password_manager_with_metadata/deploy_locally.sh
+++ b/examples/password_manager_with_metadata/deploy_locally.sh
@@ -14,6 +14,7 @@ dfx deps pull && dfx deps init && dfx deps deploy &&
     export CANISTER_ID_INTERNET_IDENTITY=rdmx6-jaaaa-aaaaa-aaadq-cai
 
 dfx canister create password_manager_with_metadata
+dfx deploy --argument '("dfx_test_key")' password_manager_with_metadata
 
 # Store environment variables for the frontend.
 echo "DFX_NETWORK=$DFX_NETWORK" > frontend/.env

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -88,7 +88,7 @@
         "test_utils": "vitest utils",
         "test": "npm run test:deploy_all && export $(cat .test1.env .test2.env | xargs) && vitest",
         "test:deploy_all": "npm run test:deploy_key_manager_canister && npm run test:deploy_encrypted_maps_canister",
-        "test:deploy_key_manager_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx start --clean --background; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env",
-        "test:deploy_encrypted_maps_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx start --clean --background; dfx deploy && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"
+        "test:deploy_key_manager_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx start --clean --background; dfx deploy --argument '(\"dfx_test_key\")' ic_vetkeys_manager_canister && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env",
+        "test:deploy_encrypted_maps_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx start --clean --background; dfx deploy --argument '(\"dfx_test_key\")' ic_vetkeys_encrypted_maps_canister && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "vetkd-devkit",
+    "name": "vetkeys",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {


### PR DESCRIPTION
So far we always initialized canisters with a hardcoded `dfx_test_key`. This change adds an `init` routine that stores the key. This now makes sense to do, since soon we will want to test the examples on mainnet.