### PR TITLE
chore: CRP-2795 publish `@dfinity/vetkeys` on new tags

### DIFF
--- a/.github/workflows/publish-frontend-docs.yml
+++ b/.github/workflows/publish-frontend-docs.yml
@@ -18,10 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ${{ github.event.inputs.tag }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
 
       - name: Build docs
         run: |

--- a/.github/workflows/publish-frontend.yml
+++ b/.github/workflows/publish-frontend.yml
@@ -1,37 +1,34 @@
-name: Publish and Release Frontend
+name: Publish @dfinity/vetkeys NPM package
 
 on:
-  pull_request:
-    branches:
-      - main
-    types:
-      - closed
+  # Triggered by git tag push
+  push:
+    tags:
+      - 'frontend/@dfinity/vetkeys/*'
 
 jobs:
   publish:
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/frontend/@dfinity/vetkeys')
+    if: startsWith(github.ref, 'refs/tags/frontend/@dfinity/vetkeys/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '23'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
       - name: Extract and validate version from branch name
         run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
-          # Get the full tag name (everything after release/)
-          VERSION_TAG="${BRANCH#release/}"
+          # Get the full tag name
+          TAG_NAME=${GITHUB_REF#refs/tags/}
           # Extract just the version number for validation
-          VERSION_NUMBER="${VERSION_TAG#frontend/@dfinity/vetkeys/}"
+          VERSION_NUMBER="${TAG_NAME#frontend/@dfinity/vetkeys/}"
           # Validate version format
           if ! [[ $VERSION_NUMBER =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Version '$VERSION_NUMBER' does not follow the required format vx.y.z"
             exit 1
           fi
-          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
-          echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_ENV
+          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
           echo "VERSION_NUMBER=$VERSION_NUMBER" >> $GITHUB_ENV
       - name: Verify package.json version
         run: |
@@ -41,11 +38,6 @@ jobs:
             echo "Error: Package.json version ($PACKAGE_VERSION) does not match release version (${VERSION_NUMBER#v})"
             exit 1
           fi
-      - name: Mark as Latest Release in GitHub Releases
-        env:
-          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-        run: |
-          gh release edit "${{ env.VERSION_TAG }}" --draft=false --prerelease=false --latest=true
       - run: |
           cd frontend/ic_vetkeys
           npm list
@@ -54,12 +46,3 @@ jobs:
           npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  delete_release_branch:
-    needs: publish
-    runs-on: ubuntu-latest
-    steps:
-      - name: Delete release branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: git push origin --delete ${{ env.BRANCH }}


### PR DESCRIPTION
This PR changes the behavior of the frontend publishing workflow (that has never run yet). The current version was inspired by the one used in `agent-js`, but it looks more complex than it should be.

Now:
1. Create a branch that will be used for PR with a name `release/frontend/@dfinity/vetkeys/$version`.
2. Create a tag pointing to that branch's `HEAD`. 
3. Create a PR with the release. Can only be merged using fast-forward or merge commits to not destroy the commit in the PR.
4. Once PR is merged, the workflow publishes the package, updates the latest release, and deletes the branch.

In this PR:
1. Create a PR with the release.
2. Merge the PR in whatever way you want and create a tag with the name `frontend/@dfinity/vetkeys/$version` from the result.
3. Once the tag is pused, the workflow starts and publishes the package.

Note that in the latter case we completely ignore github releases. Those are, however, of limited use for us, since we will have a `CHANGELOG.md` that will describe the changes and we won't publish any binaries for the frontend in github releases.