### PR TITLE
ci: CRP-2795 fix publishing workflow

### DIFF
--- a/.github/workflows/publish-frontend.yml
+++ b/.github/workflows/publish-frontend.yml
@@ -39,6 +39,7 @@ jobs:
             exit 1
           fi
       - run: |
+          npm install
           cd frontend/ic_vetkeys
           npm list
           npm run build


### PR DESCRIPTION
Added `npm install` that's needed to build the package.