### PR TITLE
ci: CRP-2795 fix publish frontend workflow by making the package public

### DIFF
--- a/.github/workflows/publish-frontend.yml
+++ b/.github/workflows/publish-frontend.yml
@@ -44,6 +44,6 @@ jobs:
           npm list
           npm run build
           npm audit
-          npm publish
+          npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -7,11 +7,11 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "https://github.com/dfinity/vetkd-devkit.git",
+        "url": "https://github.com/dfinity/vetkeys.git",
         "directory": "frontend/ic_vetkeys"
     },
     "bugs": {
-        "url": "https://github.com/dfinity/vetkd-devkit/issues"
+        "url": "https://github.com/dfinity/vetkeys/issues"
     },
     "keywords": [
         "internet computer",

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "https://github.com/dfinity/vetkeys.git",
+        "url": "git+https://github.com/dfinity/vetkeys.git",
         "directory": "frontend/ic_vetkeys"
     },
     "bugs": {


### PR DESCRIPTION
Seems the default setting for publishing packages is "restricted". This PR changes it to "public".

This PR also fixes the git URL in `package.json`.