### PR TITLE
docs: CRP-2822 adjust URLs to frontend docs to be using github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Tools to help canister developers integrate vetKeys into their Internet Computer
 
 Tools for frontend developers to interact with VetKD enabled canisters.
 
-- **[KeyManager](https://5lfyp-mqaaa-aaaag-aleqa-cai.icp0.io/classes/_dfinity_vetkeys_key_manager.KeyManager.html)** – Facilitates interaction with a KeyManager-enabled canister.
-- **[EncryptedMaps](https://5lfyp-mqaaa-aaaag-aleqa-cai.icp0.io/classes/_dfinity_vetkeys_encrypted_maps.EncryptedMaps.html)** – Facilitates interaction with a EncryptedMaps-enabled canister.
-- **[Utils](https://5lfyp-mqaaa-aaaag-aleqa-cai.icp0.io/modules/_dfinity_vetkeys.html)** – Utility functions for working with vetKeys.
+- **[KeyManager](https://dfinity.github.io/vetkeys/classes/_dfinity_vetkeys_key_manager.KeyManager.html)** – Facilitates interaction with a KeyManager-enabled canister.
+- **[EncryptedMaps](https://dfinity.github.io/vetkeys/classes/_dfinity_vetkeys_encrypted_maps.EncryptedMaps.html)** – Facilitates interaction with a EncryptedMaps-enabled canister.
+- **[Utils](https://dfinity.github.io/vetkeys/modules/_dfinity_vetkeys.html)** – Utility functions for working with vetKeys.
 
 ### **3. vetKeys Password Manager** - Example application
 

--- a/backend/rs/ic_vetkeys/README.md
+++ b/backend/rs/ic_vetkeys/README.md
@@ -3,10 +3,10 @@
 This crate contains a set of tools designed to help canister developers integrate **vetKeys** into their Internet Computer (ICP) applications.
 
 ## [Key Manager](https://docs.rs/ic-vetkeys/latest/key_manager/struct.KeyManager.html)
-A canister library for derivation of encrypted vetkeys from arbitrary strings. It can be used in combination with the [frontend key manager library](https://5lfyp-mqaaa-aaaag-aleqa-cai.icp0.io/classes/_dfinity_vetkeys_key_manager.KeyManager.html).
+A canister library for derivation of encrypted vetkeys from arbitrary strings. It can be used in combination with the [frontend key manager library](https://dfinity.github.io/vetkeys/classes/_dfinity_vetkeys_key_manager.KeyManager.html).
 
 ## [Encrypted Maps](https://docs.rs/ic-vetkeys/latest/encrypted_maps/struct.EncryptedMaps.html)
-An efficient canister library facilitating access control and encrypted storage for a collection of maps contatining key-value pairs. It can be used in combination with the [frontend encrypted maps library](https://5lfyp-mqaaa-aaaag-aleqa-cai.icp0.io/classes/_dfinity_vetkeys_encrypted_maps.EncryptedMaps.html).
+An efficient canister library facilitating access control and encrypted storage for a collection of maps contatining key-value pairs. It can be used in combination with the [frontend encrypted maps library](https://dfinity.github.io/vetkeys/classes/_dfinity_vetkeys_encrypted_maps.EncryptedMaps.html).
 
 ## [Utils](https://docs.rs/ic-vetkeys/latest/)
 For obtaining and decrypting verifiably-encrypted threshold keys via the Internet Computer vetKD system API. The API is located in the crate root.

--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,5 +1,0 @@
-{
-    "docs": {
-        "ic": "5lfyp-mqaaa-aaaag-aleqa-cai"
-    }
-}

--- a/frontend/ic_vetkeys/README.md
+++ b/frontend/ic_vetkeys/README.md
@@ -1,4 +1,4 @@
-[![documentation](https://img.shields.io/badge/documentation-online-blue)](https://5lfyp-mqaaa-aaaag-aleqa-cai.icp0.io/)
+[![documentation](https://img.shields.io/badge/documentation-online-blue)](https://dfinity.github.io/vetkeys/)
 
 # Internet Computer (ICP) VetKeys
 
@@ -8,7 +8,7 @@ This package contains three entry points:
 
 <br>
 
-[`ic_vetkeys`](https://5lfyp-mqaaa-aaaag-aleqa-cai.icp0.io/modules/_dfinity_vetkeys.html)
+[`ic_vetkeys`](https://dfinity.github.io/vetkeys/modules/_dfinity_vetkeys.html)
 
 ---
 
@@ -16,7 +16,7 @@ Provides frontend utilities for the low-level use of VetKeys such as decryption 
 
 <br>
 
-[`ic_vetkeys/key_manager`](https://5lfyp-mqaaa-aaaag-aleqa-cai.icp0.io/modules/_dfinity_vetkeys_key_manager.html)
+[`ic_vetkeys/key_manager`](https://dfinity.github.io/vetkeys/modules/_dfinity_vetkeys_key_manager.html)
 
 ---
 
@@ -24,7 +24,7 @@ A frontend library facilitating communication with a [key manager enabled canist
 
 <br>
 
-[`ic_vetkeys/encrypted_maps`](https://5lfyp-mqaaa-aaaag-aleqa-cai.icp0.io/modules/_dfinity_vetkeys_encrypted_maps.html)
+[`ic_vetkeys/encrypted_maps`](https://dfinity.github.io/vetkeys/modules/_dfinity_vetkeys_encrypted_maps.html)
 
 ---
 

--- a/scripts/gen_and_deploy_frontend_docs.sh
+++ b/scripts/gen_and_deploy_frontend_docs.sh
@@ -1,6 +1,0 @@
-IDENTITY=$1
-
-set -e
-
-./gen_frontend_docs.sh
-dfx deploy --ic --identity $IDENTITY --mode reinstall docs


### PR DESCRIPTION
* Finish docs migration to github.io
* Remove canister ids for docs
* Remove the script deploying the docs to the asset canister