### PR TITLE
fix: add package type for ES module

### DIFF
--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -54,6 +54,7 @@
             "types": "./dist/types/encrypted_maps/index.d.ts"
         }
     },
+    "main": "dist/lib/index.es.js",
     "module": "dist/lib/index.es.js",
     "typings": "dist/types/index.d.ts",
     "dependencies": {


### PR DESCRIPTION
It will throw error without `"type": "module"`:

```
import { EncryptedVetKey, DerivedPublicKey, TransportSecretKey } from '@dfinity/vetkeys'
                          ^^^^^^^^^^^^^^^^
SyntaxError: Named export 'DerivedPublicKey' not found. The requested module '@dfinity/vetkeys' is a CommonJS module, which may not support all module.exports as named exports.
```

```
 Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/Users/.../@dfinity/vetkeys/dist/lib/index.es.js:1
import { a as s, D as r, E as t, B as y, I as i, A as d, M as K, T as c, V as b, y as l, x as n, t as o, z as I } from "./index-DjVE-Mpb.mjs";
```