### PR TITLE
chore: in examples fix incorrect handling of some key ids and mainnet frontend configuration

### DIFF
--- a/examples/basic_ibe/backend/src/lib.rs
+++ b/examples/basic_ibe/backend/src/lib.rs
@@ -72,7 +72,7 @@ async fn get_root_ibe_public_key() -> VetKeyPublicKey {
     let request = VetKDPublicKeyRequest {
         canister_id: None,
         context: DOMAIN_SEPARATOR.as_bytes().to_vec(),
-        key_id: bls12_381_dfx_test_key(),
+        key_id: key_id(),
     };
 
     let (result,) = ic_cdk::api::call::call::<_, (VetKDPublicKeyReply,)>(
@@ -93,7 +93,7 @@ async fn get_my_encrypted_ibe_key(transport_key: TransportPublicKey) -> Encrypte
     let request = VetKDDeriveKeyRequest {
         input: caller.as_ref().to_vec(),
         context: DOMAIN_SEPARATOR.as_bytes().to_vec(),
-        key_id: bls12_381_dfx_test_key(),
+        key_id: key_id(),
         transport_public_key: transport_key.into_vec(),
     };
 
@@ -130,10 +130,10 @@ fn remove_my_message_by_index(message_index: usize) -> Result<(), String> {
     })
 }
 
-fn bls12_381_dfx_test_key() -> VetKDKeyId {
+fn key_id() -> VetKDKeyId {
     VetKDKeyId {
         curve: VetKDCurve::Bls12_381_G2,
-        name: "dfx_test_key".to_string(),
+        name: KEY_NAME.with_borrow(|key_name| key_name.get().clone()),
     }
 }
 

--- a/examples/basic_ibe/frontend/src/main.ts
+++ b/examples/basic_ibe/frontend/src/main.ts
@@ -37,17 +37,12 @@ function getBasicIbeCanister(): ActorSubclass<_SERVICE> {
             ? `https://${process.env.CANISTER_ID_BASIC_IBE}.ic0.app`
             : "http://localhost:8000";
 
-    basicIbeCanister = createActor(
-        process.env.CANISTER_ID_BASIC_IBE,
-        process.env.DFX_NETWORK === "ic"
-            ? undefined
-            : {
-                  agentOptions: {
-                      identity: authClient.getIdentity(),
-                      host,
-                  },
-              },
-    );
+    basicIbeCanister = createActor(process.env.CANISTER_ID_BASIC_IBE, {
+        agentOptions: {
+            identity: authClient.getIdentity(),
+            host,
+        },
+    });
 
     return basicIbeCanister;
 }

--- a/examples/basic_timelock_ibe/backend/src/lib.rs
+++ b/examples/basic_timelock_ibe/backend/src/lib.rs
@@ -107,7 +107,7 @@ async fn get_root_ibe_public_key() -> VetKeyPublicKey {
     let request = VetKDPublicKeyRequest {
         canister_id: None,
         context: DOMAIN_SEPARATOR.as_bytes().to_vec(),
-        key_id: bls12_381_dfx_test_key(),
+        key_id: key_id(),
     };
 
     let (result,) = ic_cdk::api::call::call::<_, (VetKDPublicKeyReply,)>(
@@ -306,7 +306,7 @@ async fn decrypt_bids(
     let request = VetKDDeriveKeyRequest {
         context: DOMAIN_SEPARATOR.as_bytes().to_vec(),
         input: lot_id.to_le_bytes().to_vec(),
-        key_id: bls12_381_dfx_test_key(),
+        key_id: key_id(),
         transport_public_key: transport_secret_key.public_key().to_vec(),
     };
 
@@ -374,10 +374,10 @@ fn is_authenticated() -> Result<(), String> {
     }
 }
 
-fn bls12_381_dfx_test_key() -> VetKDKeyId {
+fn key_id() -> VetKDKeyId {
     VetKDKeyId {
         curve: VetKDCurve::Bls12_381_G2,
-        name: "dfx_test_key".to_string(),
+        name: KEY_NAME.with_borrow(|key_name| key_name.get().clone()),
     }
 }
 

--- a/examples/basic_timelock_ibe/frontend/src/main.ts
+++ b/examples/basic_timelock_ibe/frontend/src/main.ts
@@ -39,14 +39,12 @@ function getBasicTimelockIbeCanister(): ActorSubclass<_SERVICE> {
 
     basicTimelockIbeCanister = createActor(
         process.env.CANISTER_ID_BASIC_TIMELOCK_IBE,
-        process.env.DFX_NETWORK === "ic"
-            ? undefined
-            : {
-                  agentOptions: {
-                      identity: authClient.getIdentity(),
-                      host,
-                  },
-              },
+        {
+            agentOptions: {
+                identity: authClient.getIdentity(),
+                host,
+            },
+        },
     );
 
     return basicTimelockIbeCanister;


### PR DESCRIPTION
- Fixed Problem 1: In some cases `agentOptions` were not passed down to the actor creation function if deploying the frontend to mainnet.

- Fixed Problem 2: In some cases the key name that was set on canister initialization was ignored and instead `"dfx_test_key"` was always used.