### PR TITLE
chore: release frontend `v0.2.0`

### DIFF
--- a/frontend/ic_vetkeys/CHANGELOG.md
+++ b/frontend/ic_vetkeys/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [0.2.0] - 06-05-2025
+
+### Fixes
+- Links in code docs.
+
+### Changes
+- The code docs now live on github.io.
+- Replaces some instances of `window` with `globalThis` in a few places for better node compatibility.
+
 ## [0.1.0] - 27-05-2025
 
 Initial release

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dfinity/vetkeys",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "author": "DFINITY Stiftung",
     "description": "JavaScript and TypeScript library to use Internet Computer vetKeys",
     "homepage": "https://internetcomputer.org/docs/building-apps/network-features/encryption/vetkeys",


### PR DESCRIPTION
See the full list of commits in https://github.com/dfinity/vetkeys/compare/backend/rs/ic_vetkeys/v0.1.0...2095b16fb4a05ca5e46ac0a3e191b5e55456188e.