### PR TITLE
fix(basic_timelock_ibe): frontend bug in displaying bids

### DIFF
--- a/examples/basic_timelock_ibe/frontend/src/main.ts
+++ b/examples/basic_timelock_ibe/frontend/src/main.ts
@@ -319,7 +319,10 @@ async function listLots() {
             heading.textContent = "Open Lots";
             fragment.appendChild(heading);
 
-            openLots.lots.reverse().forEach((lot, index) => {
+            openLots.lots.reverse();
+            openLots.bidders.reverse();
+
+            openLots.lots.forEach((lot, index) => {
                 const lotDiv = document.createElement("div");
                 lotDiv.className = "lot";
                 const isCreator =
@@ -384,7 +387,10 @@ async function listLots() {
             heading.textContent = "Closed Lots";
             fragment.appendChild(heading);
 
-            closedLots.lots.reverse().forEach((lot, index) => {
+            closedLots.lots.reverse();
+            closedLots.bids.reverse();
+
+            closedLots.lots.forEach((lot, index) => {
                 const lotDiv = document.createElement("div");
                 lotDiv.className = "lot";
                 const isWinner =

--- a/examples/basic_timelock_ibe/frontend/src/main.ts
+++ b/examples/basic_timelock_ibe/frontend/src/main.ts
@@ -320,13 +320,14 @@ async function listLots() {
             fragment.appendChild(heading);
 
             openLots.lots.reverse().forEach((lot, index) => {
+                const revIndex = openLots.lots.length - 1 - index;
                 const lotDiv = document.createElement("div");
                 lotDiv.className = "lot";
                 const isCreator =
                     lot.creator.compareTo(myPrincipal as Principal) === "eq";
                 const status = getStatusForOpenLot(
-                    openLots.lots[index],
-                    openLots.bidders[index],
+                    openLots.lots[revIndex],
+                    openLots.bidders[revIndex],
                 );
 
                 lotDiv.innerHTML = `
@@ -335,7 +336,7 @@ async function listLots() {
           <p>Creator: ${lot.creator.toText()}</p>
           <p>Closing in: ${formatCountdown(lot.end_time)}</p>
           ${status}
-          <p>Bidders:${openLots.bidders[index].length === 0 ? " no bidders yet" : openLots.bidders[index].map((bidder) => "<br>" + formatPrincipal(bidder)).join("")}</p>
+          <p>Bidders:${openLots.bidders[revIndex].length === 0 ? " no bidders yet" : openLots.bidders[revIndex].map((bidder) => "<br>" + formatPrincipal(bidder)).join("")}</p>
           ${
               !isCreator
                   ? `
@@ -385,6 +386,7 @@ async function listLots() {
             fragment.appendChild(heading);
 
             closedLots.lots.reverse().forEach((lot, index) => {
+                const revIndex = closedLots.lots.length - 1 - index;
                 const lotDiv = document.createElement("div");
                 lotDiv.className = "lot";
                 const isWinner =
@@ -394,7 +396,7 @@ async function listLots() {
                     ) === "eq";
                 const status = getStatusForClosedLot(
                     lot,
-                    closedLots.bids[index],
+                    closedLots.bids[revIndex],
                 );
 
                 lotDiv.innerHTML = `
@@ -405,9 +407,9 @@ async function listLots() {
           <p>Ended at: ${new Date(Number(lot.end_time) / 1000000).toLocaleString()}</p>
           ${status}
           <p>Bids: ${
-              closedLots.bids[index].length === 0
+              closedLots.bids[revIndex].length === 0
                   ? " no bids"
-                  : closedLots.bids[index]
+                  : closedLots.bids[revIndex]
                         .map(
                             (bid) =>
                                 `<br>${formatPrincipal(

--- a/examples/basic_timelock_ibe/frontend/src/main.ts
+++ b/examples/basic_timelock_ibe/frontend/src/main.ts
@@ -320,14 +320,13 @@ async function listLots() {
             fragment.appendChild(heading);
 
             openLots.lots.reverse().forEach((lot, index) => {
-                const revIndex = openLots.lots.length - 1 - index;
                 const lotDiv = document.createElement("div");
                 lotDiv.className = "lot";
                 const isCreator =
                     lot.creator.compareTo(myPrincipal as Principal) === "eq";
                 const status = getStatusForOpenLot(
-                    openLots.lots[revIndex],
-                    openLots.bidders[revIndex],
+                    openLots.lots[index],
+                    openLots.bidders[index],
                 );
 
                 lotDiv.innerHTML = `
@@ -336,7 +335,7 @@ async function listLots() {
           <p>Creator: ${lot.creator.toText()}</p>
           <p>Closing in: ${formatCountdown(lot.end_time)}</p>
           ${status}
-          <p>Bidders:${openLots.bidders[revIndex].length === 0 ? " no bidders yet" : openLots.bidders[revIndex].map((bidder) => "<br>" + formatPrincipal(bidder)).join("")}</p>
+          <p>Bidders:${openLots.bidders[index].length === 0 ? " no bidders yet" : openLots.bidders[index].map((bidder) => "<br>" + formatPrincipal(bidder)).join("")}</p>
           ${
               !isCreator
                   ? `
@@ -386,7 +385,6 @@ async function listLots() {
             fragment.appendChild(heading);
 
             closedLots.lots.reverse().forEach((lot, index) => {
-                const revIndex = closedLots.lots.length - 1 - index;
                 const lotDiv = document.createElement("div");
                 lotDiv.className = "lot";
                 const isWinner =
@@ -396,7 +394,7 @@ async function listLots() {
                     ) === "eq";
                 const status = getStatusForClosedLot(
                     lot,
-                    closedLots.bids[revIndex],
+                    closedLots.bids[index],
                 );
 
                 lotDiv.innerHTML = `
@@ -407,9 +405,9 @@ async function listLots() {
           <p>Ended at: ${new Date(Number(lot.end_time) / 1000000).toLocaleString()}</p>
           ${status}
           <p>Bids: ${
-              closedLots.bids[revIndex].length === 0
+              closedLots.bids[index].length === 0
                   ? " no bids"
-                  : closedLots.bids[revIndex]
+                  : closedLots.bids[index]
                         .map(
                             (bid) =>
                                 `<br>${formatPrincipal(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "vetkd-devkit",
+    "name": "vetkeys",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "vetkeys",
+    "name": "vetkd-devkit",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {


### PR DESCRIPTION
We reversed the lots based on their timestamp but used non-inverted indexing. This means that we displayed bid information as if the lots would not be reversed.

(This did not affect the correctness of the submitted bid AFAICT because that didn't use the wrong index variable.)