### PR TITLE
chore: update developer docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ vetkd_public_key : (vetkd_public_key_args) -> (vetkd_public_key_result);
 vetkd_derive_key : (vetkd_derive_key_args) -> (vetkd_derive_key_result);
 ```
 
-For more documentation on vetKeys and the management canister API, see the [vetKeys documentation](https://internetcomputer.org/docs/building-apps/network-features/encryption/vetkeys).
+For more documentation on vetKeys and the management canister API, see the [vetKeys documentation](https://internetcomputer.org/docs/building-apps/network-features/vetkeys/introduction).
 
 Please share your feedback on the [developer forum](https://forum.dfinity.org/t/threshold-key-derivation-privacy-on-the-ic/16560/179).
 

--- a/backend/mo/ic_vetkeys/src/encrypted_maps/EncryptedMaps.mo
+++ b/backend/mo/ic_vetkeys/src/encrypted_maps/EncryptedMaps.mo
@@ -2,7 +2,7 @@
 ///
 /// **EncryptedMaps** is designed to facilitate secure, encrypted data sharing between users on the Internet Computer (ICP) using the **vetKeys** feature. It allows developers to store encrypted key-value pairs (**maps**) securely and to manage fine-grained user access.
 ///
-/// For an introduction to **vetKeys**, refer to the [vetKeys Overview](https://internetcomputer.org/docs/building-apps/network-features/encryption/vetkeys).
+/// For an introduction to **vetKeys**, refer to the [vetKeys Overview](https://internetcomputer.org/docs/building-apps/network-features/vetkeys/introduction).
 ///
 /// ## Core Features
 ///

--- a/backend/mo/ic_vetkeys/src/key_manager/KeyManager.mo
+++ b/backend/mo/ic_vetkeys/src/key_manager/KeyManager.mo
@@ -2,7 +2,7 @@
 ///
 /// **vetKeys** is a feature of the Internet Computer (ICP) that enables the derivation of **encrypted cryptographic keys**. This library simplifies the process of key retrieval, encryption, and controlled sharing, ensuring secure and efficient key management for canisters and users.
 ///
-/// For an introduction to **vetKeys**, refer to the [vetKeys Overview](https://internetcomputer.org/docs/building-apps/network-features/encryption/vetkeys).
+/// For an introduction to **vetKeys**, refer to the [vetKeys Overview](https://internetcomputer.org/docs/building-apps/network-features/vetkeys/introduction).
 ///
 /// ## Core Features
 ///

--- a/backend/rs/ic_vetkeys/src/encrypted_maps/mod.rs
+++ b/backend/rs/ic_vetkeys/src/encrypted_maps/mod.rs
@@ -21,7 +21,7 @@ type Memory = VirtualMemory<DefaultMemoryImpl>;
 ///
 /// **EncryptedMaps** is designed to facilitate secure, encrypted data sharing between users on the Internet Computer (ICP) using the **vetKeys** feature. It allows developers to store encrypted key-value pairs (**maps**) securely and to manage fine-grained user access.
 ///
-/// For an introduction to **vetKeys**, refer to the [vetKeys Overview](https://internetcomputer.org/docs/building-apps/network-features/encryption/vetKeys).
+/// For an introduction to **vetKeys**, refer to the [vetKeys Overview](https://internetcomputer.org/docs/building-apps/network-features/vetkeys/introduction).
 ///
 /// ## Core Features
 ///

--- a/backend/rs/ic_vetkeys/src/key_manager/mod.rs
+++ b/backend/rs/ic_vetkeys/src/key_manager/mod.rs
@@ -21,7 +21,7 @@ type Memory = VirtualMemory<DefaultMemoryImpl>;
 ///
 /// **vetKeys** is a feature of the Internet Computer (ICP) that enables the derivation of **encrypted cryptographic keys**. This library simplifies the process of key retrieval, encryption, and controlled sharing, ensuring secure and efficient key management for canisters and users.
 ///
-/// For an introduction to **vetKeys**, refer to the [vetKeys Overview](https://internetcomputer.org/docs/building-apps/network-features/encryption/vetkeys).
+/// For an introduction to **vetKeys**, refer to the [vetKeys Overview](https://internetcomputer.org/docs/building-apps/network-features/vetkeys/introduction).
 ///
 /// ## Core Features
 ///

--- a/examples/basic_ibe/README.md
+++ b/examples/basic_ibe/README.md
@@ -3,7 +3,7 @@
 > [!IMPORTANT]  
 > These support libraries are under active development and are subject to change. Access to the repositories have been opened to allow for early feedback. Please check back regularly for updates.
 
-The **Basic IBE** example demonstrates how to use **[VetKeys](https://internetcomputer.org/docs/building-apps/network-features/encryption/vetkeys)** to implement secure messaging between users by means of Identity Based Encryption (IBE) on the **Internet Computer (IC)**. This application allows users to send encrypted messages to other users using their **Internet Identity Principal** as the encryption key identifier. This canister (IC smart contract) ensures that only the authorized user can access their private decryption key, meaning that even if someone else knows your principal, they cannot decrypt messages intended for you because neither other users nor this canister can access your private key.
+The **Basic IBE** example demonstrates how to use **[VetKeys](https://internetcomputer.org/docs/building-apps/network-features/vetkeys/introduction)** to implement secure messaging between users by means of Identity Based Encryption (IBE) on the **Internet Computer (IC)**. This application allows users to send encrypted messages to other users using their **Internet Identity Principal** as the encryption key identifier. This canister (IC smart contract) ensures that only the authorized user can access their private decryption key, meaning that even if someone else knows your principal, they cannot decrypt messages intended for you because neither other users nor this canister can access your private key.
 
 Note that generally it is possible for a canister to request a decryption key to decrypt secrets as part of its code.
 However, doing so requires the canister to provide its own transport key instead of requesting a user's transport key and this inherently makes secrets public.
@@ -58,4 +58,4 @@ npm run dev
 
 ## Additional Resources
 
-- **[What are VetKeys](https://internetcomputer.org/docs/building-apps/network-features/encryption/vetkeys)** - For more information about VetKeys and VetKD.
+- **[What are VetKeys](https://internetcomputer.org/docs/building-apps/network-features/vetkeys/introduction)** - For more information about VetKeys and VetKD.

--- a/examples/basic_timelock_ibe/README.md
+++ b/examples/basic_timelock_ibe/README.md
@@ -3,7 +3,7 @@
 > [!IMPORTANT]  
 > These support libraries are under active development and are subject to change. Access to the repositories have been opened to allow for early feedback. Please check back regularly for updates.
 
-The **Basic Timelock IBE** example demonstrates how to use **[VetKeys](https://internetcomputer.org/docs/building-apps/network-features/encryption/vetkeys)** to implement a secret-bid auction using Identity Based Encryption (IBE) on the **Internet Computer (IC)**. This application allows users authenticated with their **Internet Identity Principal** to create auction lots with a description and deadline, and other users to place a secret bid for the lot. The bids in this example are just dummy integer values, contrary to real-world use cases where users would place bids holding some value.
+The **Basic Timelock IBE** example demonstrates how to use **[VetKeys](https://internetcomputer.org/docs/building-apps/network-features/vetkeys/introduction)** to implement a secret-bid auction using Identity Based Encryption (IBE) on the **Internet Computer (IC)**. This application allows users authenticated with their **Internet Identity Principal** to create auction lots with a description and deadline, and other users to place a secret bid for the lot. The bids in this example are just dummy integer values, contrary to real-world use cases where users would place bids holding some value.
 
 This canister (IC smart contract) ensures that:
 1. Only authorized users can create auction lots and place secret bids until the lot is closed.
@@ -76,4 +76,4 @@ npm run dev
 ## Additional Resources
 
 - **[Basic IBE Example](../basic_ibe/)** - If you are interested in using IBE with users decrypting secrets.
-- **[What are VetKeys](https://internetcomputer.org/docs/building-apps/network-features/encryption/vetkeys)** - For more information about VetKeys and VetKD. 
+- **[What are VetKeys](https://internetcomputer.org/docs/building-apps/network-features/vetkeys/introduction)** - For more information about VetKeys and VetKD. 

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -3,7 +3,7 @@
     "version": "0.2.0",
     "author": "DFINITY Stiftung",
     "description": "JavaScript and TypeScript library to use Internet Computer vetKeys",
-    "homepage": "https://internetcomputer.org/docs/building-apps/network-features/encryption/vetkeys",
+    "homepage": "https://internetcomputer.org/docs/building-apps/network-features/vetkeys/introduction",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Updates the link to the developer docs from the old to the new format.

A redirect is currently in place that makes the old URL work seamlessly, but at some point the redirect might be removed.