### PR TITLE
chore(CRP-2787): make unit in IBE ciphertext/plaintext size helpers explicit

### DIFF
--- a/backend/rs/ic_vetkeys/src/utils/mod.rs
+++ b/backend/rs/ic_vetkeys/src/utils/mod.rs
@@ -764,12 +764,12 @@ impl IbeCiphertext {
         }
     }
 
-    /// Helper function for determining size of the IBE ciphertext
+    /// Helper function for determining the size of an IBE ciphertext in bytes.
     pub fn ciphertext_size(plaintext_size: usize) -> usize {
         plaintext_size + IBE_OVERHEAD
     }
 
-    /// Helper function for determining size of the IBE plaintext
+    /// Helper function for determining the size of an IBE plaintext in bytes.
     ///
     /// Returns None if the indicated length would be a ciphertext
     /// that is not possibly valid (due to missing required elements)

--- a/frontend/ic_vetkeys/src/utils/utils.ts
+++ b/frontend/ic_vetkeys/src/utils/utils.ts
@@ -943,7 +943,7 @@ export class IbeCiphertext {
     readonly #c3: Uint8Array;
 
     /**
-     * Helper function for determining size of the IBE ciphertext
+     * Helper function for determining the size of an IBE ciphertext in bytes.
      */
     static ciphertextSize(plaintextSize: number): number {
         if (plaintextSize < 0) {
@@ -956,7 +956,7 @@ export class IbeCiphertext {
     }
 
     /**
-     * Helper function for determining size of the IBE plaintext
+     * Helper function for determining the size of an IBE plaintext in bytes.
      */
     static plaintextSize(ciphertextSize: number): number {
         if (ciphertextSize < IBE_OVERHEAD) {


### PR DESCRIPTION
Makes the unit, namely bytes, explicit in the documentation of the helper functions to determine IBE ciphertext/plaintext size explicit.