### PR TITLE
fix(SECFIND-513): prevent NEXT_NOTE_ID to wrap around

### DIFF
--- a/examples/encrypted_notes_dapp_vetkd/rust/backend/src/lib.rs
+++ b/examples/encrypted_notes_dapp_vetkd/rust/backend/src/lib.rs
@@ -276,8 +276,12 @@ fn create_note() -> NoteId {
             assert_eq!(id_to_note.insert(new_note.id, new_note), None);
 
             NEXT_NOTE_ID.with_borrow_mut(|next_note_id| {
+                let id_plus_one = next_note_id
+                    .get()
+                    .checked_add(1)
+                    .expect("failed to increase NEXT_NOTE_ID: reached the maximum");
                 next_note_id
-                    .set(next_note_id.get() + 1)
+                    .set(id_plus_one)
                     .unwrap_or_else(|_e| ic_cdk::trap("failed to set NEXT_NOTE_ID"))
             });
             next_note_id


### PR DESCRIPTION
Prevent NEXT_NOTE_ID to wrap around by using a checked addition instead of an unchecked one. If the checked addition fails, then creating a new note simply fails, making the approach safe so that no data is lost.

The overflow issue does not affect [the respective Motoko code](https://github.com/dfinity/vetkeys/blob/main/examples/encrypted_notes_dapp_vetkd/motoko/backend/main.mo#L135), because `nextNoteId` is of type `Nat` which has [infinite precision](https://internetcomputer.org/docs/motoko/base/Nat).