### PR TITLE
test: CRP-2752 run frontend tests concurrently

### DIFF
--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -90,7 +90,7 @@
         "prettier": "prettier --write .",
         "prettier-check": "prettier --check .",
         "test_utils": "vitest utils",
-        "test": "npm run test:deploy_all && export $(cat .test1.env .test2.env | xargs) && vitest",
+        "test": "npm run test:deploy_all && export $(cat .test1.env .test2.env | xargs) && vitest --sequence.concurrent",
         "test:deploy_all": "npm run test:deploy_key_manager_canister && npm run test:deploy_encrypted_maps_canister",
         "test:deploy_key_manager_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx start --clean --background; dfx deploy --argument '(\"dfx_test_key\")' ic_vetkeys_manager_canister && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env",
         "test:deploy_encrypted_maps_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx start --clean --background; dfx deploy --argument '(\"dfx_test_key\")' ic_vetkeys_encrypted_maps_canister && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"


### PR DESCRIPTION
Pass `sequence.concurrent` to `vitest`. This instructs `vitest` to run all tests concurrently and reduces the runtime of the current tests from ~60s to ~20s. The main reason of the longer runtime was that we made quite a few update calls to pocket IC, which are not super fast. This change is important to not get problems with CI when we add more tests.

I ran this 5 times locally and didn't observe any flakiness. If this will be the case in the future, e.g., if we add more tests, then we could either try to limit the maximum number of tests running concurrently or change the strategy how we parallelize tests.