### PR TITLE
chore: improve disclaimer text

### DIFF
--- a/examples/encrypted_notes_dapp_vetkd/frontend/src/components/DisclaimerCopy.svelte
+++ b/examples/encrypted_notes_dapp_vetkd/frontend/src/components/DisclaimerCopy.svelte
@@ -1,4 +1,3 @@
 <strong>Disclaimer:</strong> This sample dapp is intended exclusively for experimental
-purpose. The backend canister may be removed or reinstalled at any time without prior
-notice. You are advised not to use this dapp for storing your critical data such
+purpose. You are advised not to use this dapp for storing your critical data such
 as keys or passwords.

--- a/examples/password_manager/frontend/src/components/DisclaimerCopy.svelte
+++ b/examples/password_manager/frontend/src/components/DisclaimerCopy.svelte
@@ -1,6 +1,5 @@
 <script lang="ts"></script>
 
 <strong>Disclaimer:</strong> This sample dapp is intended exclusively for experimental
-purpose. The backend canister may be removed or reinstalled at any time without prior
-notice. You are advised not to use this dapp for storing your critical data such
+purpose. You are advised not to use this dapp for storing your critical data such
 as keys or passwords.

--- a/examples/password_manager_with_metadata/frontend/src/components/DisclaimerCopy.svelte
+++ b/examples/password_manager_with_metadata/frontend/src/components/DisclaimerCopy.svelte
@@ -1,6 +1,5 @@
 <script lang="ts"></script>
 
 <strong>Disclaimer:</strong> This sample dapp is intended exclusively for experimental
-purpose. The backend canister may be removed or reinstalled at any time without prior
-notice. You are advised not to use this dapp for storing your critical data such
+purpose. You are advised not to use this dapp for storing your critical data such
 as keys or passwords.


### PR DESCRIPTION
The disclaimer text sounds like the canister is deployed on mainnet or relies on some other backend canister that we control. Remove the sentence that causes this.