### PR TITLE
feat: Use VetKDKeyId instead of MasterPublicKeyId

### DIFF
--- a/backend/rs/ic_vetkeys/src/utils/mod.rs
+++ b/backend/rs/ic_vetkeys/src/utils/mod.rs
@@ -154,15 +154,6 @@ pub enum PublicKeyDeserializationError {
     InvalidPublicKey,
 }
 
-/// Enumeration identifying the production master public key
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum MasterPublicKeyId {
-    /// The production key created in June 2025
-    Key1,
-    /// The test key created in May 2025
-    TestKey1,
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// A master VetKD public key
 pub struct MasterPublicKey {
@@ -218,13 +209,18 @@ impl MasterPublicKey {
     /// Return the hardcoded master public key used on IC
     ///
     /// This allows performing public key derivation offline
-    pub fn production_key(key_id: MasterPublicKeyId) -> Self {
-        match key_id {
-            MasterPublicKeyId::Key1 => Self { point: *G2_KEY_1 },
-            MasterPublicKeyId::TestKey1 => Self {
-                point: *G2_TEST_KEY_1,
-            },
+    ///
+    /// Returns None if the provided key_id is not known
+    pub fn from_key_id(key_id: &VetKDKeyId) -> Option<Self> {
+        match (key_id.curve, key_id.name.as_str()) {
+            (VetKDCurve::Bls12_381_G2, "key_1") => Some(Self::new(*G2_KEY_1)),
+            (VetKDCurve::Bls12_381_G2, "test_key_1") => Some(Self::new(*G2_TEST_KEY_1)),
+            (_, _) => None,
         }
+    }
+
+    fn new(point: G2Affine) -> Self {
+        Self { point }
     }
 }
 

--- a/backend/rs/ic_vetkeys/src/utils/mod.rs
+++ b/backend/rs/ic_vetkeys/src/utils/mod.rs
@@ -211,7 +211,7 @@ impl MasterPublicKey {
     /// This allows performing public key derivation offline
     ///
     /// Returns None if the provided key_id is not known
-    pub fn from_key_id(key_id: &VetKDKeyId) -> Option<Self> {
+    pub fn for_mainnet_key(key_id: &VetKDKeyId) -> Option<Self> {
         match (key_id.curve, key_id.name.as_str()) {
             (VetKDCurve::Bls12_381_G2, "key_1") => Some(Self::new(*G2_KEY_1)),
             (VetKDCurve::Bls12_381_G2, "test_key_1") => Some(Self::new(*G2_TEST_KEY_1)),

--- a/backend/rs/ic_vetkeys/tests/utils.rs
+++ b/backend/rs/ic_vetkeys/tests/utils.rs
@@ -1,5 +1,6 @@
 use hex_literal::hex;
 use ic_bls12_381::*;
+use ic_cdk::management_canister::{VetKDCurve, VetKDKeyId};
 use ic_vetkeys::*;
 use ic_vetkeys_test_utils::*;
 use rand::Rng;
@@ -85,7 +86,8 @@ fn test_bls_signature_verification_using_identity() {
 fn test_derivation_using_test_key_1() {
     // This test data was generated on mainnet using test_key_1
 
-    let test_key1 = MasterPublicKey::production_key(MasterPublicKeyId::TestKey1);
+    let key_id = VetKDKeyId { curve: VetKDCurve::Bls12_381_G2, name: "test_key_1".to_string() };
+    let test_key1 = MasterPublicKey::from_key_id(&key_id).unwrap();
 
     let canister_id = hex!("0000000000c0a0d00101");
 
@@ -108,7 +110,8 @@ fn test_derivation_using_test_key_1() {
 fn test_derivation_using_production_key() {
     // This test data was generated on mainnet using key_1
 
-    let key1 = MasterPublicKey::production_key(MasterPublicKeyId::Key1);
+    let key_id = VetKDKeyId { curve: VetKDCurve::Bls12_381_G2, name: "key_1".to_string() };
+    let key1 = MasterPublicKey::from_key_id(&key_id).unwrap();
 
     let canister_id = hex!("0000000000c0a0d00101");
 

--- a/backend/rs/ic_vetkeys/tests/utils.rs
+++ b/backend/rs/ic_vetkeys/tests/utils.rs
@@ -86,7 +86,10 @@ fn test_bls_signature_verification_using_identity() {
 fn test_derivation_using_test_key_1() {
     // This test data was generated on mainnet using test_key_1
 
-    let key_id = VetKDKeyId { curve: VetKDCurve::Bls12_381_G2, name: "test_key_1".to_string() };
+    let key_id = VetKDKeyId {
+        curve: VetKDCurve::Bls12_381_G2,
+        name: "test_key_1".to_string(),
+    };
     let test_key1 = MasterPublicKey::from_key_id(&key_id).unwrap();
 
     let canister_id = hex!("0000000000c0a0d00101");
@@ -110,7 +113,10 @@ fn test_derivation_using_test_key_1() {
 fn test_derivation_using_production_key() {
     // This test data was generated on mainnet using key_1
 
-    let key_id = VetKDKeyId { curve: VetKDCurve::Bls12_381_G2, name: "key_1".to_string() };
+    let key_id = VetKDKeyId {
+        curve: VetKDCurve::Bls12_381_G2,
+        name: "key_1".to_string(),
+    };
     let key1 = MasterPublicKey::from_key_id(&key_id).unwrap();
 
     let canister_id = hex!("0000000000c0a0d00101");

--- a/backend/rs/ic_vetkeys/tests/utils.rs
+++ b/backend/rs/ic_vetkeys/tests/utils.rs
@@ -90,7 +90,7 @@ fn test_derivation_using_test_key_1() {
         curve: VetKDCurve::Bls12_381_G2,
         name: "test_key_1".to_string(),
     };
-    let test_key1 = MasterPublicKey::from_key_id(&key_id).unwrap();
+    let test_key1 = MasterPublicKey::for_mainnet_key(&key_id).unwrap();
 
     let canister_id = hex!("0000000000c0a0d00101");
 
@@ -117,7 +117,7 @@ fn test_derivation_using_production_key() {
         curve: VetKDCurve::Bls12_381_G2,
         name: "key_1".to_string(),
     };
-    let key1 = MasterPublicKey::from_key_id(&key_id).unwrap();
+    let key1 = MasterPublicKey::for_mainnet_key(&key_id).unwrap();
 
     let canister_id = hex!("0000000000c0a0d00101");
 


### PR DESCRIPTION
Other interfaces including the management canister use VetKDKeyId to identify which VetKD master key to use. Use this type also for looking up hardcoded production keys instead of the one-off MasterPublicKeyId enum.