### PR TITLE
refactor: rename `derive_public_vetkey` to `derive_unencrypted_vetkey`

### DIFF
--- a/backend/rs/ic_vetkeys/src/utils/mod.rs
+++ b/backend/rs/ic_vetkeys/src/utils/mod.rs
@@ -863,8 +863,10 @@ pub mod management_canister {
 
     use super::*;
 
-    /// Derives a vetKey that is public to the canister and ICP nodes.
-    /// This function is useful if vetKeys are supposed to be decrypted by the canister itself, e.g., when vetKeys are used as BLS signatures, for timelock encryption, or for producing verifiable randomness.
+    /// Derives an unencrypted vetKey.
+    ///
+    /// Because the vetKey returned by this function is unencrypted, it is public to the canister and ICP nodes.
+    /// Therefore, this function shall only be used if the vetKey would otherwise be decrypted directly by the canister itself, e.g., when it is used as BLS signature, for timelock encryption, or for producing verifiable randomness.
     ///
     /// **Warning**: A vetKey produced by this function is *insecure* to use as a private key by a user.
     ///
@@ -879,7 +881,7 @@ pub mod management_canister {
     /// # Returns
     /// * `Ok(VetKey)` - The derived vetKey on success
     /// * `Err(DeriveUnencryptedVetkeyError)` - If derivation fails due to unsupported curve or canister call error
-    async fn derive_public_vetkey(
+    async fn derive_unencrypted_vetkey(
         input: Vec<u8>,
         context: Vec<u8>,
         key_id: VetKDKeyId,
@@ -946,7 +948,7 @@ pub mod management_canister {
         context: Vec<u8>,
         key_id: VetKDKeyId,
     ) -> Result<Vec<u8>, VetKDDeriveKeyCallError> {
-        derive_public_vetkey(message, context, key_id).await
+        derive_unencrypted_vetkey(message, context, key_id).await
     }
 
     /// Returns the public key of a threshold BLS12-381 key.


### PR DESCRIPTION
Renames `derive_public_vetkey` to `derive_unencrypted_vetkey`.

Because this is a private function only used internally, the CHANGELOG is unchanged.