### PR TITLE
chore: Update README and CHANELOG for ic_vetkeys

### DIFF
--- a/backend/rs/ic_vetkeys/CHANGELOG.md
+++ b/backend/rs/ic_vetkeys/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Added
 
-- Added MasterPublicKey::production_key which allows accessing the production public keys
+- Added MasterPublicKey::for_mainnet_key which allows accessing the production public keys
 
-- Added IbeCiphertext plaintextSize and ciphertextSize helpers
+- Added IbeCiphertext plaintext_size and ciphertext_size helpers
+
+- Add VrfOutput type for using VetKeys as a Verifiable Random Function
 
 - `derive(Deserialize)` for `EncryptedMapData`
 

--- a/backend/rs/ic_vetkeys/README.md
+++ b/backend/rs/ic_vetkeys/README.md
@@ -2,6 +2,8 @@
 
 This crate contains a set of tools designed to help canister developers integrate **vetKeys** into their Internet Computer (ICP) applications.
 
+The current Minimum Supported Rust Version (MSRV) of this crate is 1.85. Any future increase in the MSRV will be accompanied by a bump in the minor version number.
+
 ## [Key Manager](https://docs.rs/ic-vetkeys/latest/ic_vetkeys/key_manager/struct.KeyManager.html)
 A canister library for derivation of encrypted vetkeys from arbitrary strings. It can be used in combination with the [frontend key manager library](https://dfinity.github.io/vetkeys/classes/_dfinity_vetkeys_key_manager.KeyManager.html).
 


### PR DESCRIPTION
Mention MSRV in the README

Mention VrfOutput being added

Fix incorrect references in the CHANGELOG