### PR TITLE
feat: CRP-2847 Add AES-GCM encryption helpers to the Rust library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +305,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,7 +380,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -637,6 +692,16 @@ dependencies = [
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1030,6 +1095,7 @@ dependencies = [
 name = "ic-vetkeys"
 version = "0.4.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "assert_matches",
  "candid",
@@ -1299,6 +1365,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,6 +1615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,6 +1763,18 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "wslpath",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2881,6 +2974,16 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/backend/rs/ic_vetkeys/Cargo.toml
+++ b/backend/rs/ic_vetkeys/Cargo.toml
@@ -24,6 +24,7 @@ readme = "README.md"
 crate-type = ["lib"]
 
 [dependencies]
+aes-gcm = "0.10"
 anyhow = { workspace = true }
 candid = { workspace = true }
 ic_bls12_381 = { version = "0.10.1", default-features = false, features = [

--- a/backend/rs/ic_vetkeys/tests/utils.rs
+++ b/backend/rs/ic_vetkeys/tests/utils.rs
@@ -285,3 +285,72 @@ fn vrf_from_prod_can_be_verified() {
         "a484fc1e8a2b0dca99beb6f4409370f5c6932a931e47a7625c3bfe9e1f9af37f"
     );
 }
+
+#[test]
+fn aes_gcm_encryption() {
+    let dkm = DerivedKeyMaterial::new(&VetKey::deserialize(&hex!("ad19676dd92f116db11f326ff0822f295d87cc00cf65d9f132b5a618bb7381e5b0c3cb814f15e4a0f015359dcfa8a1da")).unwrap());
+
+    let test_message = b"stay calm, this is only a test";
+    let domain_sep = "ic-test-domain-sep";
+
+    // Test string encryption path, then decryption
+
+    let mut rng = reproducible_rng();
+
+    let ctext = dkm
+        .encrypt_message(test_message, domain_sep, &mut rng)
+        .unwrap();
+    assert_eq!(
+        dkm.decrypt_message(&ctext, domain_sep).unwrap(),
+        test_message,
+    );
+
+    // Test decryption of known ciphertext encrypted with the derived key
+    let fixed_ctext = hex!("476f440e30bb95fff1420ce41ba6a07e03c3fcc0a751cfb23e64a8dcb0fc2b1eb74e2d4768f5c4dccbf2526609156664046ad27a6e78bd93bb8b");
+
+    assert_eq!(
+        dkm.decrypt_message(&fixed_ctext, domain_sep).unwrap(),
+        test_message,
+    );
+
+    // Test decryption of various mutated or truncated ciphertexts: all should fail
+
+    // Test sequentially flipping each bit
+
+    for i in 0..ctext.len() * 8 {
+        let mod_ctext = {
+            let mut m = ctext.clone();
+            m[i / 8] ^= 0x80 >> i % 8;
+            m
+        };
+
+        assert!(dkm.decrypt_message(&mod_ctext, domain_sep).is_err());
+    }
+
+    // Test truncating
+
+    for i in 0..ctext.len() - 1 {
+        let mod_ctext = {
+            let mut m = ctext.clone();
+            m.truncate(i);
+            m
+        };
+
+        assert!(dkm.decrypt_message(&mod_ctext, domain_sep).is_err());
+    }
+
+    // Test appending random bytes
+
+    for i in 1..32 {
+        let mod_ctext = {
+            use rand::RngCore;
+            let mut m = ctext.clone();
+            let mut extra = vec![0u8; i];
+            rng.fill_bytes(&mut extra);
+            m.extend_from_slice(&extra);
+            m
+        };
+
+        assert!(dkm.decrypt_message(&mod_ctext, domain_sep).is_err());
+    }
+}


### PR DESCRIPTION
This matches the behavior of the functions in the TS frontend library