### PR TITLE
feat: CRP-2911 Modify AES-GCM encryption to be more robust

### DIFF
--- a/backend/rs/ic_vetkeys/tests/utils.rs
+++ b/backend/rs/ic_vetkeys/tests/utils.rs
@@ -302,7 +302,6 @@ fn aes_gcm_encryption() {
         .encrypt_message(test_message, domain_sep, aad, &mut rng)
         .unwrap();
 
-    println!("{}", hex::encode(&ctext));
     assert_eq!(
         dkm.decrypt_message(&ctext, domain_sep, aad).unwrap(),
         test_message,

--- a/backend/rs/ic_vetkeys/tests/utils.rs
+++ b/backend/rs/ic_vetkeys/tests/utils.rs
@@ -292,24 +292,27 @@ fn aes_gcm_encryption() {
 
     let test_message = b"stay calm, this is only a test";
     let domain_sep = "ic-test-domain-sep";
+    let aad = b"some additional authenticated data";
 
     // Test string encryption path, then decryption
 
     let mut rng = reproducible_rng();
 
     let ctext = dkm
-        .encrypt_message(test_message, domain_sep, &mut rng)
+        .encrypt_message(test_message, domain_sep, aad, &mut rng)
         .unwrap();
+
+    println!("{}", hex::encode(&ctext));
     assert_eq!(
-        dkm.decrypt_message(&ctext, domain_sep).unwrap(),
+        dkm.decrypt_message(&ctext, domain_sep, aad).unwrap(),
         test_message,
     );
 
     // Test decryption of known ciphertext encrypted with the derived key
-    let fixed_ctext = hex!("476f440e30bb95fff1420ce41ba6a07e03c3fcc0a751cfb23e64a8dcb0fc2b1eb74e2d4768f5c4dccbf2526609156664046ad27a6e78bd93bb8b");
+    let fixed_ctext = hex!("49432047434d76325dc1b0f5f8deec973adda66ce7cb9dc06118c738fae12027c5bae5b86e69ffd633ddfc0ea66c4df37b6e7e298d9f80170ec3d51c4238be9a63bd");
 
     assert_eq!(
-        dkm.decrypt_message(&fixed_ctext, domain_sep).unwrap(),
+        dkm.decrypt_message(&fixed_ctext, domain_sep, aad).unwrap(),
         test_message,
     );
 
@@ -324,7 +327,7 @@ fn aes_gcm_encryption() {
             m
         };
 
-        assert!(dkm.decrypt_message(&mod_ctext, domain_sep).is_err());
+        assert!(dkm.decrypt_message(&mod_ctext, domain_sep, aad).is_err());
     }
 
     // Test truncating
@@ -336,7 +339,7 @@ fn aes_gcm_encryption() {
             m
         };
 
-        assert!(dkm.decrypt_message(&mod_ctext, domain_sep).is_err());
+        assert!(dkm.decrypt_message(&mod_ctext, domain_sep, aad).is_err());
     }
 
     // Test appending random bytes
@@ -351,6 +354,6 @@ fn aes_gcm_encryption() {
             m
         };
 
-        assert!(dkm.decrypt_message(&mod_ctext, domain_sep).is_err());
+        assert!(dkm.decrypt_message(&mod_ctext, domain_sep, aad).is_err());
     }
 }

--- a/frontend/ic_vetkeys/src/utils/utils.ts
+++ b/frontend/ic_vetkeys/src/utils/utils.ts
@@ -540,9 +540,8 @@ const DERIVED_KEY_MATERIAL_NONCE_LENGTH = 12;
 
 const DERIVED_KEY_MATERIAL_VERSION = 2;
 
-const DERIVED_KEY_MATERIAL_HEADER_BYTES = new Uint8Array([
-    0x49, 0x43, 0x20, 0x47, 0x43, 0x4D, 0x76, 0x32,
-]);
+const DERIVED_KEY_MATERIAL_HEADER = "IC GCMv2";
+const DERIVED_KEY_MATERIAL_HEADER_BYTES = new TextEncoder().encode(DERIVED_KEY_MATERIAL_HEADER);
 const DERIVED_KEY_MATERIAL_HEADER_LEN = 8;
 
 
@@ -604,13 +603,11 @@ export class DerivedKeyMaterial {
         domainSep: Uint8Array | string,
         version: number,
     ): Promise<CryptoKey> {
-        const exportable = false;
-
         const algorithm = {
             name: "HKDF",
             hash: "SHA-256",
             length: 32 * 8,
-            info: withPrefix("ic-vetkd-bls12-381-g2-aes-gcm-v" + version.toString(), domainSep),
+            info: withPrefix("ic-vetkd-bls12-381-g2-aes-gcm-v" + version.toString() + "-", domainSep),
             salt: new Uint8Array(),
         };
 
@@ -618,6 +615,8 @@ export class DerivedKeyMaterial {
             name: "AES-GCM",
             length: 32 * 8,
         };
+
+        const exportable = false;
 
         return globalThis.crypto.subtle.deriveKey(
             algorithm,
@@ -636,6 +635,7 @@ export class DerivedKeyMaterial {
     async encryptMessage(
         message: Uint8Array | string,
         domainSep: Uint8Array | string,
+        associatedData: Uint8Array | string,
     ): Promise<Uint8Array> {
         const gcmKey = await this.deriveAesGcmCryptoKey(domainSep, DERIVED_KEY_MATERIAL_VERSION);
 
@@ -644,9 +644,11 @@ export class DerivedKeyMaterial {
             new Uint8Array(DERIVED_KEY_MATERIAL_NONCE_LENGTH),
         );
 
+        const aad = withPrefix(DERIVED_KEY_MATERIAL_HEADER, associatedData);
+
         const ciphertext = new Uint8Array(
             await globalThis.crypto.subtle.encrypt(
-                { name: "AES-GCM", iv: nonce },
+                { name: "AES-GCM", iv: nonce, additionalData: aad },
                 gcmKey,
                 asBytes(message),
             ),
@@ -664,6 +666,7 @@ export class DerivedKeyMaterial {
     async decryptMessage(
         message: Uint8Array,
         domainSep: Uint8Array | string,
+        associatedData: Uint8Array | string,
     ): Promise<Uint8Array> {
         const GCM_TAG_LENGTH = 16;
 
@@ -682,18 +685,19 @@ export class DerivedKeyMaterial {
         // the ciphertext accordingly.
         if(!isEqual(header, DERIVED_KEY_MATERIAL_HEADER_BYTES)) {
             throw new Error(
-                "Invalid ciphertext, too short to possibly be valid",
+                "Unknown header for AES-GCM encrypted ciphertext",
             );
         }
 
-        const nonce = message.slice(DERIVED_KEY_MATERIAL_HEADER_LEN, DERIVED_KEY_MATERIAL_NONCE_LENGTH); // next 12 bytes are the nonce
-        const ciphertext = message.slice(DERIVED_KEY_MATERIAL_HEADER_LEN + DERIVED_KEY_MATERIAL_NONCE_LENGTH); // remainder GCM ciphertext
+        const aad = withPrefix(DERIVED_KEY_MATERIAL_HEADER, associatedData);
 
+        const nonce = message.slice(DERIVED_KEY_MATERIAL_HEADER_LEN, DERIVED_KEY_MATERIAL_HEADER_LEN + DERIVED_KEY_MATERIAL_NONCE_LENGTH); // next 12 bytes are the nonce
+        const ciphertext = message.slice(DERIVED_KEY_MATERIAL_HEADER_LEN + DERIVED_KEY_MATERIAL_NONCE_LENGTH); // remainder GCM ciphertext
         const gcmKey = await this.deriveAesGcmCryptoKey(domainSep, DERIVED_KEY_MATERIAL_VERSION);
 
         try {
             const ptext = await globalThis.crypto.subtle.decrypt(
-                { name: "AES-GCM", iv: nonce },
+                { name: "AES-GCM", iv: nonce, additionalData: aad },
                 gcmKey,
                 ciphertext,
             );

--- a/frontend/ic_vetkeys/src/utils/utils.ts
+++ b/frontend/ic_vetkeys/src/utils/utils.ts
@@ -337,6 +337,19 @@ function asBytes(input: Uint8Array | string): Uint8Array {
 }
 
 /**
+ * @internal helper for data encoding
+ */
+function withPrefix(prefix: string, input: Uint8Array | string): Uint8Array {
+    const prefixBytes = new TextEncoder().encode(prefix);
+    const inputBytes = asBytes(input);
+
+    const result = new Uint8Array(prefixBytes.length + inputBytes.length);
+    result.set(prefixBytes, 0);
+    result.set(inputBytes, prefixBytes.length);
+    return result;
+}
+
+/**
  * @internal derive a symmetric key from the provided input
  *
  * The `input` parameter should be a sufficiently long random input generated
@@ -489,7 +502,7 @@ export class VetKey {
      * Return a DerivedKeyMaterial type which is suitable for further key derivation
      */
     async asDerivedKeyMaterial(): Promise<DerivedKeyMaterial> {
-        return DerivedKeyMaterial.setup(this.#bytes);
+        return DerivedKeyMaterial.setup(this.deriveSymmetricKey("ic-vetkd-bls12-381-g2-derived-key-material", 32));
     }
 
     /**
@@ -524,6 +537,14 @@ export class VetKey {
 
 // The size of the nonce used for encryption by DerivedKeyMaterial
 const DERIVED_KEY_MATERIAL_NONCE_LENGTH = 12;
+
+const DERIVED_KEY_MATERIAL_VERSION = 2;
+
+const DERIVED_KEY_MATERIAL_HEADER_BYTES = new Uint8Array([
+    0x49, 0x43, 0x20, 0x47, 0x43, 0x4D, 0x76, 0x32,
+]);
+const DERIVED_KEY_MATERIAL_HEADER_LEN = 8;
+
 
 /*
  * Derived Key Material
@@ -579,8 +600,9 @@ export class DerivedKeyMaterial {
      *
      * The CryptoKey is not exportable
      */
-    async deriveAesGcmCryptoKey(
+    private async deriveAesGcmCryptoKey(
         domainSep: Uint8Array | string,
+        version: number,
     ): Promise<CryptoKey> {
         const exportable = false;
 
@@ -588,7 +610,7 @@ export class DerivedKeyMaterial {
             name: "HKDF",
             hash: "SHA-256",
             length: 32 * 8,
-            info: asBytes(domainSep),
+            info: withPrefix("ic-vetkd-bls12-381-g2-aes-gcm-v" + version.toString(), domainSep),
             salt: new Uint8Array(),
         };
 
@@ -615,7 +637,7 @@ export class DerivedKeyMaterial {
         message: Uint8Array | string,
         domainSep: Uint8Array | string,
     ): Promise<Uint8Array> {
-        const gcmKey = await this.deriveAesGcmCryptoKey(domainSep);
+        const gcmKey = await this.deriveAesGcmCryptoKey(domainSep, DERIVED_KEY_MATERIAL_VERSION);
 
         // The nonce must never be reused with a given key
         const nonce = globalThis.crypto.getRandomValues(
@@ -631,7 +653,7 @@ export class DerivedKeyMaterial {
         );
 
         // Concatenate the nonce to the beginning of the ciphertext
-        return new Uint8Array([...nonce, ...ciphertext]);
+        return new Uint8Array([...DERIVED_KEY_MATERIAL_HEADER_BYTES, ...nonce, ...ciphertext]);
     }
 
     /**
@@ -645,19 +667,29 @@ export class DerivedKeyMaterial {
     ): Promise<Uint8Array> {
         const GCM_TAG_LENGTH = 16;
 
-        if (
-            message.length <
-            DERIVED_KEY_MATERIAL_NONCE_LENGTH + GCM_TAG_LENGTH
-        ) {
+        const minLen = DERIVED_KEY_MATERIAL_HEADER_LEN + DERIVED_KEY_MATERIAL_NONCE_LENGTH + GCM_TAG_LENGTH
+        if(message.length < minLen) {
             throw new Error(
                 "Invalid ciphertext, too short to possibly be valid",
             );
         }
 
-        const nonce = message.slice(0, DERIVED_KEY_MATERIAL_NONCE_LENGTH); // first 12 bytes are the nonce
-        const ciphertext = message.slice(DERIVED_KEY_MATERIAL_NONCE_LENGTH); // remainder GCM ciphertext
+        const header = message.slice(0, DERIVED_KEY_MATERIAL_HEADER_LEN); // first 8 bytes are the header
 
-        const gcmKey = await this.deriveAesGcmCryptoKey(domainSep);
+        // If multiple versions are ever supported in the future, and we
+        // must retain backward compatability, then this would need to be
+        // extended to check for multiple different headers and process
+        // the ciphertext accordingly.
+        if(!isEqual(header, DERIVED_KEY_MATERIAL_HEADER_BYTES)) {
+            throw new Error(
+                "Invalid ciphertext, too short to possibly be valid",
+            );
+        }
+
+        const nonce = message.slice(DERIVED_KEY_MATERIAL_HEADER_LEN, DERIVED_KEY_MATERIAL_NONCE_LENGTH); // next 12 bytes are the nonce
+        const ciphertext = message.slice(DERIVED_KEY_MATERIAL_HEADER_LEN + DERIVED_KEY_MATERIAL_NONCE_LENGTH); // remainder GCM ciphertext
+
+        const gcmKey = await this.deriveAesGcmCryptoKey(domainSep, DERIVED_KEY_MATERIAL_VERSION);
 
         try {
             const ptext = await globalThis.crypto.subtle.decrypt(


### PR DESCRIPTION
Changes include

* `DerivedKeyMaterial` is, instead of being just the raw VetKey treated as an HKDF key, is first hashed. This prevents working backwards from a `DerivedKeyMaterial` to the original `VetKey`.
* The user specified domain separator is prefixed with our own specific domain separator
* The GCM ciphertexts now include an 8 byte header with a version field to allow easier transitions in the future
* Key derivation takes into account both the user specified domain separator and the ciphertext version
* Added support for associated data

These changes are not backwards compatible. Backwards compatability could be added in the future if required (eg if the header is unknown, attempt to decrypt using the old scheme - if it works, return the recovered plaintext). The hope is that this is not required.