### PR TITLE
fix(crypto): encrypted_notes example: use persistent actor

### DIFF
--- a/.github/workflows/examples-encrypted-notes-dapp.yml
+++ b/.github/workflows/examples-encrypted-notes-dapp.yml
@@ -12,6 +12,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+env:
+  DFX_VERSION: 0.29.1
 jobs:
   examples-encrypted-notes-dapp-rust-darwin:
     runs-on: macos-15

--- a/examples/encrypted_notes_dapp_vetkd/motoko/dfx.json
+++ b/examples/encrypted_notes_dapp_vetkd/motoko/dfx.json
@@ -32,7 +32,7 @@
     },
     "networks": {
       "local": {
-        "bind": "localhost:8000",
+        "bind": "127.0.0.1:8000",
         "type": "ephemeral"
       }
     }

--- a/examples/encrypted_notes_dapp_vetkd/rust/dfx.json
+++ b/examples/encrypted_notes_dapp_vetkd/rust/dfx.json
@@ -32,7 +32,7 @@
   },
   "networks": {
     "local": {
-      "bind": "localhost:8000",
+      "bind": "127.0.0.1:8000",
       "type": "ephemeral"
     }
   }


### PR DESCRIPTION
Adapts the encrypted_notes_dapp example so that it works again with ICP Ninja, which recently upgraded to DFX 0.29.1, which ships with a new motoko compiler (0.16.1). The necessary changes for this were

* Declaring the actor as `persistent`
* Marking all transient variables explicitly as transient, and removing the redundant stable keywords.

Note that the example still uses the old way to persist data across updates, which is serialize/deserialize data in the preupgrade and postupgrade methods.

The Github workflow sets the `DFX_VERSION` environment variable, so that only this example uses the new DFX version 0.29.1. This also required to change the bind host from `localhost` to `127.0.0.1` as otherwise this new DFX version hits the following error:
```
Error: The replica returned an HTTP Error: Http Error: status 400 Bad Request, content type "text/plain; charset=utf-8", content: error: no_authority
details:
The request is missing the required authority information (e.g. 'Host' header).
```

The changes were tested in ICP Ninja with the following link:

[![](https://icp.ninja/assets/open.svg)](http://icp.ninja/editor?g=https://github.com/dfinity/vetkeys/tree/franzstefan/CRP-2924-enc-notes/examples/encrypted_notes_dapp_vetkd/motoko)