### PR TITLE
fix(crypto): password manager examples: use persistent actor

### DIFF
--- a/.github/workflows/examples-password-manager-with-metadata.yml
+++ b/.github/workflows/examples-password-manager-with-metadata.yml
@@ -13,6 +13,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+env:
+  DFX_VERSION: 0.29.1
 jobs:
   examples-password-manager-with-metadata-rust-darwin:
     runs-on: macos-15

--- a/.github/workflows/examples-password-manager.yml
+++ b/.github/workflows/examples-password-manager.yml
@@ -13,6 +13,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+env:
+  DFX_VERSION: 0.29.1
 jobs:
   examples-password-manager-rust-darwin:
     runs-on: macos-15

--- a/backend/mo/canisters/ic_vetkeys_encrypted_maps_canister/mops.toml
+++ b/backend/mo/canisters/ic_vetkeys_encrypted_maps_canister/mops.toml
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 [dependencies]
 base = "0.14.6"
-ic-vetkeys = "0.3.0"
+ic-vetkeys = "0.4.0"

--- a/backend/mo/canisters/ic_vetkeys_encrypted_maps_canister/src/Main.mo
+++ b/backend/mo/canisters/ic_vetkeys_encrypted_maps_canister/src/Main.mo
@@ -1,4 +1,5 @@
-import IcVetkeys "mo:ic-vetkeys";
+// import IcVetkeys "mo:ic-vetkeys";
+import IcVetkeys "../../../../../backend/mo/ic_vetkeys/src";
 import Types "mo:ic-vetkeys/Types";
 import Principal "mo:base/Principal";
 import Text "mo:base/Text";
@@ -6,8 +7,10 @@ import Blob "mo:base/Blob";
 import Result "mo:base/Result";
 import Array "mo:base/Array";
 
-actor class (keyName : Text) {
-    var encryptedMaps = IcVetkeys.EncryptedMaps.EncryptedMaps<Types.AccessRights>({ curve = #bls12_381_g2; name = keyName }, "encrypted maps dapp", Types.accessRightsOperations());
+persistent actor class (keyName : Text) {
+    let encryptedMapsState = IcVetkeys.EncryptedMaps.newEncryptedMapsState<Types.AccessRights>({ curve = #bls12_381_g2; name = keyName }, "password_manager_example_dapp");
+    transient let encryptedMaps = IcVetkeys.EncryptedMaps.EncryptedMaps<Types.AccessRights>(encryptedMapsState, Types.accessRightsOperations());
+
     /// In this canister, we use the `ByteBuf` type to represent blobs. The reason is that we want to be consistent with the Rust canister implementation.
     /// Unfortunately, the `Blob` type cannot be serialized/deserialized in the current Rust implementation efficiently without nesting it in another type.
     public type ByteBuf = { inner : Blob };

--- a/backend/mo/canisters/ic_vetkeys_encrypted_maps_canister/src/Main.mo
+++ b/backend/mo/canisters/ic_vetkeys_encrypted_maps_canister/src/Main.mo
@@ -1,4 +1,4 @@
-import IcVetkeys "../../../../../backend/mo/ic_vetkeys/src";
+import IcVetkeys "mo:ic-vetkeys";
 import Types "mo:ic-vetkeys/Types";
 import Principal "mo:base/Principal";
 import Text "mo:base/Text";

--- a/backend/mo/canisters/ic_vetkeys_encrypted_maps_canister/src/Main.mo
+++ b/backend/mo/canisters/ic_vetkeys_encrypted_maps_canister/src/Main.mo
@@ -1,4 +1,3 @@
-// import IcVetkeys "mo:ic-vetkeys";
 import IcVetkeys "../../../../../backend/mo/ic_vetkeys/src";
 import Types "mo:ic-vetkeys/Types";
 import Principal "mo:base/Principal";

--- a/examples/password_manager/motoko/mops.toml
+++ b/examples/password_manager/motoko/mops.toml
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 
 [dependencies]
 base = "0.14.6"
-ic-vetkeys = "0.2.0"
+ic-vetkeys = "0.4.0"

--- a/examples/password_manager_with_metadata/motoko/backend/src/Main.mo
+++ b/examples/password_manager_with_metadata/motoko/backend/src/Main.mo
@@ -9,7 +9,7 @@ import Time "mo:base/Time";
 import Nat64 "mo:base/Nat64";
 import Int "mo:base/Int";
 import Debug "mo:base/Debug";
-import VetKeys "../../../../../backend/mo/ic_vetkeys/src";
+import VetKeys "mo:ic-vetkeys";
 
 persistent actor class (keyName : Text) {
 

--- a/examples/password_manager_with_metadata/motoko/backend/src/Main.mo
+++ b/examples/password_manager_with_metadata/motoko/backend/src/Main.mo
@@ -9,18 +9,13 @@ import Time "mo:base/Time";
 import Nat64 "mo:base/Nat64";
 import Int "mo:base/Int";
 import Debug "mo:base/Debug";
-import VetKeys "mo:ic-vetkeys";
+import VetKeys "../../../../../backend/mo/ic_vetkeys/src";
 
-actor class (keyName : Text) {
+persistent actor class (keyName : Text) {
 
   // Global state
-  let accessRightsOperations = VetKeys.accessRightsOperations();
-  let keyId = { curve = #bls12_381_g2; name = keyName };
-  let encryptedMaps = VetKeys.EncryptedMaps.EncryptedMaps<VetKeys.AccessRights>(
-    keyId,
-    "password_manager_dapp",
-    accessRightsOperations,
-  );
+  let encryptedMapsState = VetKeys.EncryptedMaps.newEncryptedMapsState<VetKeys.AccessRights>({ curve = #bls12_381_g2; name = keyName }, "password_manager_example_dapp");
+  transient let encryptedMaps = VetKeys.EncryptedMaps.EncryptedMaps<VetKeys.AccessRights>(encryptedMapsState, VetKeys.accessRightsOperations());
 
   func compareMetadataKeys(a : MetadataKey, b : MetadataKey) : {
     #less;
@@ -39,7 +34,7 @@ actor class (keyName : Text) {
       ownerCompare;
     };
   };
-  let metadataMapOps = OrderedMap.Make<MetadataKey>(compareMetadataKeys);
+  transient let metadataMapOps = OrderedMap.Make<MetadataKey>(compareMetadataKeys);
   var metadata : OrderedMap.Map<MetadataKey, PasswordMetadata> = metadataMapOps.empty<PasswordMetadata>();
 
   // Types
@@ -249,7 +244,7 @@ actor class (keyName : Text) {
     access_rights : VetKeys.AccessRights,
   ) : async Result<?VetKeys.AccessRights, Text> {
     let mapId = (map_owner, map_name.inner);
-    convertResult(encryptedMaps.keyManager.setUserRights(caller, mapId, user, access_rights));
+    convertResult(encryptedMaps.setUserRights(caller, mapId, user, access_rights));
   };
 
   public shared ({ caller }) func remove_user(
@@ -258,6 +253,6 @@ actor class (keyName : Text) {
     user : Principal,
   ) : async Result<?VetKeys.AccessRights, Text> {
     let mapId = (map_owner, map_name.inner);
-    convertResult(encryptedMaps.keyManager.removeUserRights(caller, mapId, user));
+    convertResult(encryptedMaps.removeUser(caller, mapId, user));
   };
 };

--- a/examples/password_manager_with_metadata/motoko/dfx.json
+++ b/examples/password_manager_with_metadata/motoko/dfx.json
@@ -42,7 +42,7 @@
     },
     "networks": {
       "local": {
-        "bind": "localhost:8000",
+        "bind": "127.0.0.1:8000",
         "type": "ephemeral"
       }
     }

--- a/examples/password_manager_with_metadata/motoko/mops.toml
+++ b/examples/password_manager_with_metadata/motoko/mops.toml
@@ -1,3 +1,3 @@
 [dependencies]
 base = "0.14.9"
-ic-vetkeys = "0.2.0"
+ic-vetkeys = "0.4.0"

--- a/examples/password_manager_with_metadata/rust/dfx.json
+++ b/examples/password_manager_with_metadata/rust/dfx.json
@@ -36,7 +36,7 @@
   },
   "networks": {
     "local": {
-      "bind": "localhost:8000",
+      "bind": "127.0.0.1:8000",
       "type": "ephemeral"
     }
   }


### PR DESCRIPTION
Adapts the password_manager and password_manager_with_metadata examples so that they work again with ICP Ninja, which recently upgraded to DFX 0.29.1, which ships with a new motoko compiler (0.16.1). The necessary changes for this were

* Declaring the actor as `persistent` and fixing the compiler issues

The Github workflow sets the `DFX_VERSION` environment variable, so that only this example uses the new DFX version 0.29.1. This also required to change the bind host from `localhost` to `127.0.0.1` as otherwise this new DFX version hits the following error:
```
Error: The replica returned an HTTP Error: Http Error: status 400 Bad Request, content type "text/plain; charset=utf-8", content: error: no_authority
details:
The request is missing the required authority information (e.g. 'Host' header).
```

The changes were tested in ICP Ninja with the following link:

Password manager:
[![](https://icp.ninja/assets/open.svg)](http://icp.ninja/editor?g=https://github.com/dfinity/vetkeys/tree/franzstefan/CRP-2924-password-managers/examples/password_manager/motoko)

Password manager with metadata:
[![](https://icp.ninja/assets/open.svg)](http://icp.ninja/editor?g=https://github.com/dfinity/vetkeys/tree/franzstefan/CRP-2924-password-managers/examples/password_manager_with_metadata/motoko)