### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/backend-motoko-format-check.yml
+++ b/.github/workflows/backend-motoko-format-check.yml
@@ -17,10 +17,10 @@ jobs:
   backend-motoko-format-check-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: ZenVoich/setup-mops@v1
+      - uses: ZenVoich/setup-mops@3e94e453352269b34137b5ce49f09a8df81bed7d # v1.4.1
         with:
           mops-version: 1
       - name: Provision Linux

--- a/.github/workflows/backend-motoko.yml
+++ b/.github/workflows/backend-motoko.yml
@@ -21,10 +21,10 @@ jobs:
   backend-motoko-tests-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: ZenVoich/setup-mops@v1
+      - uses: ZenVoich/setup-mops@3e94e453352269b34137b5ce49f09a8df81bed7d # v1.4.1
         with:
           mops-version: 1
       - name: Provision Linux
@@ -42,10 +42,10 @@ jobs:
   backend-motoko-tests-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - uses: ZenVoich/setup-mops@v1
+      - uses: ZenVoich/setup-mops@3e94e453352269b34137b5ce49f09a8df81bed7d # v1.4.1
         with:
           mops-version: 1
       - name: Provision Darwin

--- a/.github/workflows/backend-rust-canbench.yml
+++ b/.github/workflows/backend-rust-canbench.yml
@@ -21,7 +21,7 @@ jobs:
   cargo-benchmark-backend-ibe-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Linux

--- a/.github/workflows/backend-rust.yml
+++ b/.github/workflows/backend-rust.yml
@@ -21,7 +21,7 @@ jobs:
   cargo-test-backend-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Linux
@@ -36,7 +36,7 @@ jobs:
   cargo-test-backend-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Darwin

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -23,7 +23,7 @@ jobs:
   cargo-clippy-backend-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Linux

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -12,7 +12,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: dfinity/conventional-pr-title-action@v4.0.0
+      - uses: dfinity/conventional-pr-title-action@41fbb167fd524835beda2b81882b7c75b1061dbc # v4.0.0
         with:
           success-state: Title follows the specification.
           failure-state: Title does not follow the specification.

--- a/.github/workflows/examples-basic-bls-signing.yml
+++ b/.github/workflows/examples-basic-bls-signing.yml
@@ -21,7 +21,7 @@ jobs:
   examples-basic-bls-signing-rust-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Darwin
@@ -38,7 +38,7 @@ jobs:
   examples-basic-bls-signing-rust-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Linux
@@ -54,7 +54,7 @@ jobs:
   examples-basic-bls-signing-motoko-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Darwin
@@ -71,7 +71,7 @@ jobs:
   examples-basic-bls-signing-motoko-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Linux

--- a/.github/workflows/examples-basic-ibe.yml
+++ b/.github/workflows/examples-basic-ibe.yml
@@ -20,7 +20,7 @@ jobs:
   examples-basic-ibe-rust-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Darwin
@@ -37,7 +37,7 @@ jobs:
   examples-basic-ibe-rust-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Linux
@@ -53,7 +53,7 @@ jobs:
   examples-basic-ibe-motoko-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Darwin
@@ -70,7 +70,7 @@ jobs:
   examples-basic-ibe-motoko-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Linux

--- a/.github/workflows/examples-basic-timelock-ibe.yml
+++ b/.github/workflows/examples-basic-timelock-ibe.yml
@@ -19,7 +19,7 @@ jobs:
   examples-basic-timelock-ibe-rust-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Darwin
@@ -36,7 +36,7 @@ jobs:
   examples-basic-timelock-ibe-rust-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Linux

--- a/.github/workflows/examples-encrypted-chat.yml
+++ b/.github/workflows/examples-encrypted-chat.yml
@@ -19,7 +19,7 @@ jobs:
   examples-encrypted-chat-rust-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
@@ -31,7 +31,7 @@ jobs:
   examples-encrypted-chat-rust-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Backend Tests Encrypted Chat Rust Linux

--- a/.github/workflows/examples-encrypted-notes-dapp.yml
+++ b/.github/workflows/examples-encrypted-notes-dapp.yml
@@ -20,7 +20,7 @@ jobs:
   examples-encrypted-notes-dapp-rust-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Darwin
@@ -34,7 +34,7 @@ jobs:
   examples-encrypted-notes-dapp-rust-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Linux
@@ -47,7 +47,7 @@ jobs:
   examples-encrypted-notes-dapp-motoko-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Darwin
@@ -61,7 +61,7 @@ jobs:
   examples-encrypted-notes-dapp-motoko-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Linux

--- a/.github/workflows/examples-password-manager-with-metadata.yml
+++ b/.github/workflows/examples-password-manager-with-metadata.yml
@@ -22,7 +22,7 @@ jobs:
   examples-password-manager-with-metadata-rust-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Darwin
@@ -39,7 +39,7 @@ jobs:
   examples-password-manager-with-metadata-rust-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Linux
@@ -55,7 +55,7 @@ jobs:
   examples-password-manager-with-metadata-motoko-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Darwin
@@ -72,7 +72,7 @@ jobs:
   examples-password-manager-with-metadata-motoko-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Linux

--- a/.github/workflows/examples-password-manager.yml
+++ b/.github/workflows/examples-password-manager.yml
@@ -22,7 +22,7 @@ jobs:
   examples-password-manager-rust-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Darwin
@@ -38,7 +38,7 @@ jobs:
   examples-password-manager-rust-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Linux
@@ -53,7 +53,7 @@ jobs:
   examples-password-manager-motoko-darwin:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Darwin
@@ -69,7 +69,7 @@ jobs:
   examples-password-manager-motoko-linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Linux

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -21,7 +21,7 @@ jobs:
   frontend_ic_vetkeys_linux:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Linux
@@ -37,7 +37,7 @@ jobs:
   frontend_ic_vetkeys_mac:
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Provision Darwin

--- a/.github/workflows/publish-frontend-docs.yml
+++ b/.github/workflows/publish-frontend-docs.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ${{ github.event.inputs.tag }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag }}
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -35,9 +35,9 @@ jobs:
           bash ./scripts/gen_frontend_docs.sh
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: docs
 
       - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/publish-frontend.yml
+++ b/.github/workflows/publish-frontend.yml
@@ -15,11 +15,11 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `ZenVoich/setup-mops@v1` -> `ZenVoich/setup-mops@3e94e453352269b34137b5ce49f09a8df81bed7d # v1.4.1`
  - Version: v1.4.1 | Latest: v1.4.1 | Release age: 567d
  - Commit: https://github.com/ZenVoich/setup-mops/commit/3e94e453352269b34137b5ce49f09a8df81bed7d

- `dfinity/conventional-pr-title-action@v4.0.0` -> `dfinity/conventional-pr-title-action@41fbb167fd524835beda2b81882b7c75b1061dbc # v4.0.0`
  - Version: v4.0.0 | Latest: v3.2.0 | Release age: 687d
  - Commit: https://github.com/dfinity/conventional-pr-title-action/commit/41fbb167fd524835beda2b81882b7c75b1061dbc
  - Warnings: FORK of aslafy-z/conventional-pr-title-action, FORK of aslafy-z/conventional-pr-title-action

- `actions/setup-node@v4` -> `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0`
  - Version: v4.4.0 | Latest: v6.3.0 | Release age: 36d
  - Commit: https://github.com/actions/setup-node/commit/49933ea5288caeca8642d1e84afbd3f7d6820020

- `actions/upload-pages-artifact@v3` -> `actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1`
  - Version: v3.0.1 | Latest: v4.0.0 | Release age: 237d
  - Commit: https://github.com/actions/upload-pages-artifact/commit/56afc609e74202658d3ffba0e8f6dda462b719fa

- `actions/deploy-pages@v4` -> `actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5`
  - Version: v4.0.5 | Latest: v5.0.0 | Release age: 14d
  - Commit: https://github.com/actions/deploy-pages/commit/d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e


### Files modified

- `.github/workflows/backend-motoko-format-check.yml`
- `.github/workflows/backend-motoko.yml`
- `.github/workflows/backend-rust-canbench.yml`
- `.github/workflows/backend-rust.yml`
- `.github/workflows/clippy.yml`
- `.github/workflows/conventional-commits.yml`
- `.github/workflows/examples-basic-bls-signing.yml`
- `.github/workflows/examples-basic-ibe.yml`
- `.github/workflows/examples-basic-timelock-ibe.yml`
- `.github/workflows/examples-encrypted-chat.yml`
- `.github/workflows/examples-encrypted-notes-dapp.yml`
- `.github/workflows/examples-password-manager-with-metadata.yml`
- `.github/workflows/examples-password-manager.yml`
- `.github/workflows/frontend.yml`
- `.github/workflows/publish-frontend-docs.yml`
- `.github/workflows/publish-frontend.yml`

### Security warnings

- FORK of aslafy-z/conventional-pr-title-action