### PR TITLE
feat: migrate @dfinity/* imports to @icp-sdk/core

### DIFF
--- a/.github/workflows/examples-basic-bls-signing.yml
+++ b/.github/workflows/examples-basic-bls-signing.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Basic BLS Signing Rust Darwin
         run: |
           set -eExuo pipefail
@@ -43,6 +48,11 @@ jobs:
           persist-credentials: false
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Basic BLS Signing Rust Linux
         run: |
           set -eExuo pipefail
@@ -60,6 +70,11 @@ jobs:
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Basic BLS Signing Motoko Darwin
         run: |
           set -eExuo pipefail
@@ -76,6 +91,11 @@ jobs:
           persist-credentials: false
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Basic BLS Signing Motoko Linux
         run: |
           set -eExuo pipefail

--- a/.github/workflows/examples-basic-ibe.yml
+++ b/.github/workflows/examples-basic-ibe.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Basic IBE Rust Darwin
         run: |
           set -eExuo pipefail
@@ -42,6 +47,11 @@ jobs:
           persist-credentials: false
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Basic IBE Rust Linux
         run: |
           set -eExuo pipefail
@@ -59,6 +69,11 @@ jobs:
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Basic IBE Motoko Darwin
         run: |
           set -eExuo pipefail
@@ -75,6 +90,11 @@ jobs:
           persist-credentials: false
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Basic IBE Motoko Linux
         run: |
           set -eExuo pipefail
@@ -82,4 +102,4 @@ jobs:
           pushd examples/basic_ibe/motoko
           dfx start --background && dfx deploy
           cd frontend
-          npm run lint 
+          npm run lint

--- a/.github/workflows/examples-basic-timelock-ibe.yml
+++ b/.github/workflows/examples-basic-timelock-ibe.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Basic Timelock IBE Darwin
         run: |
           set -eExuo pipefail
@@ -41,6 +46,11 @@ jobs:
           persist-credentials: false
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Basic Timelock IBE Linux
         run: |
           set -eExuo pipefail
@@ -48,4 +58,4 @@ jobs:
           pushd examples/basic_timelock_ibe
           dfx start --background && dfx deploy
           cd frontend
-          npm run lint 
+          npm run lint

--- a/.github/workflows/examples-encrypted-chat.yml
+++ b/.github/workflows/examples-encrypted-chat.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Backend Tests Encrypted Chat Rust Darwin
         run: |
           set -eExuo pipefail
@@ -34,6 +39,11 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Backend Tests Encrypted Chat Rust Linux
         run: |
           set -eExuo pipefail

--- a/.github/workflows/examples-encrypted-notes-dapp.yml
+++ b/.github/workflows/examples-encrypted-notes-dapp.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Encrypted Notes Dapp VetKD Darwin
         run: |
           set -eExuo pipefail
@@ -39,6 +44,11 @@ jobs:
           persist-credentials: false
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Encrypted Notes Dapp VetKD Linux
         run: |
           set -eExuo pipefail
@@ -53,6 +63,11 @@ jobs:
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Encrypted Notes Dapp VetKD Darwin
         run: |
           set -eExuo pipefail
@@ -66,6 +81,11 @@ jobs:
           persist-credentials: false
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Encrypted Notes Dapp VetKD Linux
         run: |
           set -eExuo pipefail

--- a/.github/workflows/examples-password-manager-with-metadata.yml
+++ b/.github/workflows/examples-password-manager-with-metadata.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Password Manager With Metadata Darwin
         run: |
           set -eExuo pipefail
@@ -44,6 +49,11 @@ jobs:
           persist-credentials: false
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Password Manager With Metadata Linux
         run: |
           set -eExuo pipefail
@@ -61,6 +71,11 @@ jobs:
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Password Manager With Metadata Darwin
         run: |
           set -eExuo pipefail
@@ -77,6 +92,11 @@ jobs:
           persist-credentials: false
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Password Manager With Metadata Linux
         run: |
           set -eExuo pipefail

--- a/.github/workflows/examples-password-manager.yml
+++ b/.github/workflows/examples-password-manager.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Password Manager Darwin
         run: |
           set -eExuo pipefail
@@ -43,6 +48,11 @@ jobs:
           persist-credentials: false
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Password Manager Linux
         run: |
           set -eExuo pipefail
@@ -59,6 +69,11 @@ jobs:
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Password Manager Darwin
         run: |
           set -eExuo pipefail
@@ -74,6 +89,11 @@ jobs:
           persist-credentials: false
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+      - name: Install workspace dependencies
+        run: npm install
       - name: Deploy Password Manager Linux
         run: |
           set -eExuo pipefail

--- a/examples/basic_bls_signing/frontend/package.json
+++ b/examples/basic_bls_signing/frontend/package.json
@@ -24,8 +24,8 @@
         "vite-plugin-environment": "^1.1.3"
     },
     "dependencies": {
-        "@dfinity/auth-client": "^2.4.1",
-        "@dfinity/principal": "^2.4.1",
-        "@dfinity/vetkeys": "^0.3.0"
+        "@dfinity/vetkeys": "file:../../../frontend/ic_vetkeys",
+        "@icp-sdk/auth": "^5.0.0",
+        "@icp-sdk/core": "^5.0.0"
     }
 }

--- a/examples/basic_bls_signing/frontend/scripts/gen_bindings.sh
+++ b/examples/basic_bls_signing/frontend/scripts/gen_bindings.sh
@@ -9,3 +9,7 @@ rm -r frontend/src/declarations/basic_bls_signing > /dev/null 2>&1 || true
 mkdir -p frontend/src/declarations/basic_bls_signing
 mv src/declarations/basic_bls_signing frontend/src/declarations
 rmdir -p src/declarations > /dev/null 2>&1 || true
+
+# Rewrite @dfinity/* imports to @icp-sdk/core/* in generated declarations
+find frontend/src/declarations -type f \( -name "*.ts" -o -name "*.js" \) -exec \
+  perl -i -pe 's|\@dfinity/agent|\@icp-sdk/core/agent|g; s|\@dfinity/principal|\@icp-sdk/core/principal|g; s|\@dfinity/candid|\@icp-sdk/core/candid|g' {} +

--- a/examples/basic_bls_signing/frontend/src/main.ts
+++ b/examples/basic_bls_signing/frontend/src/main.ts
@@ -5,9 +5,9 @@ if (!window.global) {
 
 import "./style.css";
 import { createActor } from "./declarations/basic_bls_signing";
-import { Principal } from "@dfinity/principal";
-import { AuthClient } from "@dfinity/auth-client";
-import type { ActorSubclass } from "@dfinity/agent";
+import { Principal } from "@icp-sdk/core/principal";
+import { AuthClient } from "@icp-sdk/auth/client";
+import type { ActorSubclass } from "@icp-sdk/core/agent";
 import { _SERVICE } from "./declarations/basic_bls_signing/basic_bls_signing.did";
 import { DerivedPublicKey, verifyBlsSignature } from "@dfinity/vetkeys";
 import type { Signature } from "./declarations/basic_bls_signing/basic_bls_signing.did";

--- a/examples/basic_ibe/frontend/package.json
+++ b/examples/basic_ibe/frontend/package.json
@@ -24,8 +24,8 @@
     "vite-plugin-environment": "^1.1.3"
   },
   "dependencies": {
-    "@dfinity/auth-client": "^2.4.1",
-    "@dfinity/principal": "^2.4.1",
-    "@dfinity/vetkeys": "^0.3.0"
+    "@dfinity/vetkeys": "file:../../../frontend/ic_vetkeys",
+    "@icp-sdk/auth": "^5.0.0",
+    "@icp-sdk/core": "^5.0.0"
   }
 }

--- a/examples/basic_ibe/frontend/scripts/gen_bindings.sh
+++ b/examples/basic_ibe/frontend/scripts/gen_bindings.sh
@@ -9,3 +9,7 @@ rm -r frontend/src/declarations/basic_ibe > /dev/null 2>&1 || true
 mkdir -p frontend/src/declarations/basic_ibe
 mv src/declarations/basic_ibe frontend/src/declarations
 rmdir -p src/declarations > /dev/null 2>&1 || true
+
+# Rewrite @dfinity/* imports to @icp-sdk/core/* in generated declarations
+find frontend/src/declarations -type f \( -name "*.ts" -o -name "*.js" \) -exec \
+  perl -i -pe 's|\@dfinity/agent|\@icp-sdk/core/agent|g; s|\@dfinity/principal|\@icp-sdk/core/principal|g; s|\@dfinity/candid|\@icp-sdk/core/candid|g' {} +

--- a/examples/basic_ibe/frontend/src/main.ts
+++ b/examples/basic_ibe/frontend/src/main.ts
@@ -1,6 +1,6 @@
 import "./style.css";
 import { createActor } from "./declarations/basic_ibe";
-import { Principal } from "@dfinity/principal";
+import { Principal } from "@icp-sdk/core/principal";
 import {
     TransportSecretKey,
     DerivedPublicKey,
@@ -11,8 +11,8 @@ import {
     IbeSeed,
 } from "@dfinity/vetkeys";
 import { Inbox, _SERVICE } from "./declarations/basic_ibe/basic_ibe.did";
-import { AuthClient } from "@dfinity/auth-client";
-import type { ActorSubclass } from "@dfinity/agent";
+import { AuthClient } from "@icp-sdk/auth/client";
+import type { ActorSubclass } from "@icp-sdk/core/agent";
 
 let ibePrivateKey: VetKey | undefined = undefined;
 let ibePublicKey: DerivedPublicKey | undefined = undefined;

--- a/examples/basic_timelock_ibe/frontend/package.json
+++ b/examples/basic_timelock_ibe/frontend/package.json
@@ -24,9 +24,8 @@
     "vite-plugin-environment": "^1.1.3"
   },
   "dependencies": {
-    "@dfinity/agent": "^2.4.1",
-    "@dfinity/auth-client": "^2.4.1",
-    "@dfinity/principal": "^2.4.1",
-    "@dfinity/vetkeys": "^0.3.0"
+    "@dfinity/vetkeys": "file:../../../frontend/ic_vetkeys",
+    "@icp-sdk/auth": "^5.0.0",
+    "@icp-sdk/core": "^5.0.0"
   }
 }

--- a/examples/basic_timelock_ibe/frontend/scripts/gen_bindings.sh
+++ b/examples/basic_timelock_ibe/frontend/scripts/gen_bindings.sh
@@ -2,3 +2,7 @@
 
 cd ../../backend && make extract-candid && dfx generate basic_timelock_ibe && cd ../frontend && rm -r ./src/declarations >> /dev/null 2>&1
 mv ../src/declarations ./src && rmdir ../src
+
+# Rewrite @dfinity/* imports to @icp-sdk/core/* in generated declarations
+find ./src/declarations -type f \( -name "*.ts" -o -name "*.js" \) -exec \
+  perl -i -pe 's|\@dfinity/agent|\@icp-sdk/core/agent|g; s|\@dfinity/principal|\@icp-sdk/core/principal|g; s|\@dfinity/candid|\@icp-sdk/core/candid|g' {} +

--- a/examples/basic_timelock_ibe/frontend/src/main.ts
+++ b/examples/basic_timelock_ibe/frontend/src/main.ts
@@ -5,7 +5,7 @@ if (!window.global) {
 
 import "./style.css";
 import { createActor } from "./declarations/basic_timelock_ibe";
-import { Principal } from "@dfinity/principal";
+import { Principal } from "@icp-sdk/core/principal";
 import {
     DerivedPublicKey,
     IbeCiphertext,
@@ -16,8 +16,8 @@ import {
     _SERVICE,
     LotInformation,
 } from "./declarations/basic_timelock_ibe/basic_timelock_ibe.did";
-import { AuthClient } from "@dfinity/auth-client";
-import type { ActorSubclass } from "@dfinity/agent";
+import { AuthClient } from "@icp-sdk/auth/client";
+import type { ActorSubclass } from "@icp-sdk/core/agent";
 
 let ibePublicKey: DerivedPublicKey | undefined = undefined;
 let myPrincipal: Principal | undefined = undefined;

--- a/examples/encrypted_chat/frontend/package.json
+++ b/examples/encrypted_chat/frontend/package.json
@@ -44,9 +44,9 @@
 		"vite-plugin-environment": "^1.1.3"
 	},
 	"dependencies": {
-		"@dfinity/agent": "^3.1.0",
-		"@dfinity/auth-client": "^3.1.0",
-		"@dfinity/vetkeys": "^0.4.0",
+		"@dfinity/vetkeys": "file:../../../frontend/ic_vetkeys",
+		"@icp-sdk/auth": "^5.0.0",
+		"@icp-sdk/core": "^5.0.0",
 		"@melt-ui/svelte": "^0.86.6",
 		"@skeletonlabs/skeleton": "^3.1.7",
 		"@skeletonlabs/tw-plugin": "^0.4.1",

--- a/examples/encrypted_chat/frontend/scripts/gen_bindings.sh
+++ b/examples/encrypted_chat/frontend/scripts/gen_bindings.sh
@@ -9,3 +9,7 @@ rm -r frontend/src/declarations/encrypted_chat > /dev/null 2>&1 || true
 mkdir -p frontend/src/declarations/encrypted_chat
 mv src/declarations/encrypted_chat frontend/src/declarations
 rmdir -p src/declarations > /dev/null 2>&1 || true
+
+# Rewrite @dfinity/* imports to @icp-sdk/core/* in generated declarations
+find frontend/src/declarations -type f \( -name "*.ts" -o -name "*.js" \) -exec \
+  perl -i -pe 's|\@dfinity/agent|\@icp-sdk/core/agent|g; s|\@dfinity/principal|\@icp-sdk/core/principal|g; s|\@dfinity/candid|\@icp-sdk/core/candid|g' {} +

--- a/examples/encrypted_chat/frontend/src/lib/components/ChatHeader.svelte
+++ b/examples/encrypted_chat/frontend/src/lib/components/ChatHeader.svelte
@@ -6,7 +6,7 @@
 	import { canisterAPI } from '../services/canisterApi';
 	import { chatUIActions } from '../stores/chat.svelte';
 	import GroupManagementModal from './GroupManagementModal.svelte';
-	import { Principal } from '@dfinity/principal';
+	import { Principal } from '@icp-sdk/core/principal';
 	import { chatIdFromString } from '$lib/utils';
 
 	const {

--- a/examples/encrypted_chat/frontend/src/lib/components/GroupManagementModal.svelte
+++ b/examples/encrypted_chat/frontend/src/lib/components/GroupManagementModal.svelte
@@ -3,7 +3,7 @@
 	import { UserMinus, X, Save, Users } from 'lucide-svelte';
 	import type { GroupChat } from '../types';
 	import { getMyPrincipal } from '$lib/stores/auth.svelte';
-	import { Principal } from '@dfinity/principal';
+	import { Principal } from '@icp-sdk/core/principal';
 	import Card from './ui/Card.svelte';
 	import Button from './ui/Button.svelte';
 

--- a/examples/encrypted_chat/frontend/src/lib/crypto/keyManager.ts
+++ b/examples/encrypted_chat/frontend/src/lib/crypto/keyManager.ts
@@ -1,5 +1,5 @@
 import { SymmetricRatchetState } from './symmetricRatchet';
-import { Principal } from '@dfinity/principal';
+import { Principal } from '@icp-sdk/core/principal';
 
 export class KeyManager {
 	#symmetricRatchetStates: Map<string, Map<bigint, SymmetricRatchetState>> = new Map();

--- a/examples/encrypted_chat/frontend/src/lib/crypto/symmetricRatchet.ts
+++ b/examples/encrypted_chat/frontend/src/lib/crypto/symmetricRatchet.ts
@@ -4,7 +4,7 @@ import {
 	u8ByteUint8ArrayBigEndianToUBigInt,
 	uBigIntTo8ByteUint8ArrayBigEndian
 } from '../utils';
-import { Principal } from '@dfinity/principal';
+import { Principal } from '@icp-sdk/core/principal';
 
 const DOMAIN_RATCHET_INIT = sizePrefixedBytesFromString('ic-vetkeys-chat-ratchet-init');
 const DOMAIN_RATCHET_STEP = sizePrefixedBytesFromString('ic-vetkeys-chat-ratchet-step');

--- a/examples/encrypted_chat/frontend/src/lib/services/canisterApi.ts
+++ b/examples/encrypted_chat/frontend/src/lib/services/canisterApi.ts
@@ -1,4 +1,4 @@
-import type { ActorSubclass } from '@dfinity/agent';
+import type { ActorSubclass } from '@icp-sdk/core/agent';
 import type { SymmetricRatchetStats } from '../types';
 import type {
 	_SERVICE,
@@ -8,7 +8,7 @@ import type {
 	UserMessage,
 	VetKeyEpochMetadata
 } from '../../declarations/encrypted_chat/encrypted_chat.did';
-import { Principal } from '@dfinity/principal';
+import { Principal } from '@icp-sdk/core/principal';
 import { stringifyBigInt } from '$lib/utils';
 import { TransportSecretKey, EncryptedVetKey, DerivedPublicKey, VetKey } from '@dfinity/vetkeys';
 

--- a/examples/encrypted_chat/frontend/src/lib/services/chatStorage.ts
+++ b/examples/encrypted_chat/frontend/src/lib/services/chatStorage.ts
@@ -3,7 +3,7 @@ import type { Message, Chat, UserConfig } from '../types';
 import { storagePrefixes } from '../types';
 import * as cbor from 'cbor-x';
 import { fromHex, toHex } from '$lib/utils';
-import { Principal } from '@dfinity/principal';
+import { Principal } from '@icp-sdk/core/principal';
 
 // IndexedDB storage service for persistent chat data
 export class ChatStorageService {

--- a/examples/encrypted_chat/frontend/src/lib/services/encryptedCanisterCacheService.ts
+++ b/examples/encrypted_chat/frontend/src/lib/services/encryptedCanisterCacheService.ts
@@ -12,7 +12,7 @@ import {
 	type EncryptedMapsClient
 } from '@dfinity/vetkeys/encrypted_maps';
 import type { ChatId } from '../../declarations/encrypted_chat/encrypted_chat.did';
-import type { Principal } from '@dfinity/principal';
+import type { Principal } from '@icp-sdk/core/principal';
 import { getActor, getMyPrincipal } from '$lib/stores/auth.svelte';
 
 export class EncryptedCanisterCacheService {

--- a/examples/encrypted_chat/frontend/src/lib/services/encryptedMessagingService.ts
+++ b/examples/encrypted_chat/frontend/src/lib/services/encryptedMessagingService.ts
@@ -1,5 +1,5 @@
 import { auth, getActor, getMyPrincipal } from '$lib/stores/auth.svelte';
-import type { ActorSubclass } from '@dfinity/agent';
+import type { ActorSubclass } from '@icp-sdk/core/agent';
 import type {
 	_SERVICE,
 	ChatId,

--- a/examples/encrypted_chat/frontend/src/lib/services/vetKeyResharingService.ts
+++ b/examples/encrypted_chat/frontend/src/lib/services/vetKeyResharingService.ts
@@ -9,7 +9,7 @@ import {
 } from '@dfinity/vetkeys';
 import type { ChatId } from '../../declarations/encrypted_chat/encrypted_chat.did';
 import { keyStorageService } from './keyStorage';
-import type { Principal } from '@dfinity/principal';
+import type { Principal } from '@icp-sdk/core/principal';
 import { getActor, getMyPrincipal } from '$lib/stores/auth.svelte';
 
 export class VetKeyResharingService {

--- a/examples/encrypted_chat/frontend/src/lib/stores/auth.svelte.ts
+++ b/examples/encrypted_chat/frontend/src/lib/stores/auth.svelte.ts
@@ -1,7 +1,7 @@
 import { chatStorageService } from '$lib/services/chatStorage';
-import { HttpAgent, type ActorSubclass } from '@dfinity/agent';
-import { AuthClient } from '@dfinity/auth-client';
-import type { Principal } from '@dfinity/principal';
+import { HttpAgent, type ActorSubclass } from '@icp-sdk/core/agent';
+import { AuthClient } from '@icp-sdk/auth/client';
+import type { Principal } from '@icp-sdk/core/principal';
 import type { _SERVICE } from '../../declarations/encrypted_chat/encrypted_chat.did';
 import { createActor } from '../../declarations/encrypted_chat';
 import fetch from 'isomorphic-fetch';

--- a/examples/encrypted_chat/frontend/src/lib/stores/chat.svelte.ts
+++ b/examples/encrypted_chat/frontend/src/lib/stores/chat.svelte.ts
@@ -13,7 +13,7 @@ import type {
 	ChatId,
 	GroupModification
 } from '../../declarations/encrypted_chat/encrypted_chat.did';
-import { Principal } from '@dfinity/principal';
+import { Principal } from '@icp-sdk/core/principal';
 import { chatIdFromString, chatIdToString } from '$lib/utils';
 import { EncryptedMessagingService } from '$lib/services/encryptedMessagingService';
 import * as cbor from 'cbor-x';

--- a/examples/encrypted_chat/frontend/src/lib/types/index.ts
+++ b/examples/encrypted_chat/frontend/src/lib/types/index.ts
@@ -1,4 +1,4 @@
-import { Principal } from '@dfinity/principal';
+import { Principal } from '@icp-sdk/core/principal';
 
 export interface User {
 	principal: Principal;

--- a/examples/encrypted_chat/frontend/src/lib/utils/index.ts
+++ b/examples/encrypted_chat/frontend/src/lib/utils/index.ts
@@ -1,5 +1,5 @@
 import type { ChatId } from '../../declarations/encrypted_chat/encrypted_chat.did';
-import { Principal } from '@dfinity/principal';
+import { Principal } from '@icp-sdk/core/principal';
 
 export function chatIdToString(chatId: ChatId): string {
 	if ('Group' in chatId) return `group/${chatId.Group.toString()}`;

--- a/examples/encrypted_notes_dapp_vetkd/frontend/package.json
+++ b/examples/encrypted_notes_dapp_vetkd/frontend/package.json
@@ -27,7 +27,7 @@
     "@tailwindcss/line-clamp": "^0.3.1",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/svelte": "^3.0.3",
-    "@tsconfig/svelte": "^2.0.0",
+    "@tsconfig/svelte": "^5.0.0",
     "autoprefixer": "^10.4.2",
     "babel-jest": "^27.4.6",
     "daisyui": "^1.25.4",
@@ -48,15 +48,12 @@
     "svelte-preprocess": "^5.0.3",
     "tailwindcss": "^3.0.17",
     "tslib": "^2.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^5.7.0"
   },
   "dependencies": {
-    "@dfinity/agent": "^2.1.3",
-    "@dfinity/auth-client": "^2.1.3",
-    "@dfinity/candid": "^2.1.3",
-    "@dfinity/identity": "^2.1.3",
-    "@dfinity/principal": "^2.1.3",
-    "@dfinity/vetkeys": "^0.3.0",
+    "@dfinity/vetkeys": "file:../../../frontend/ic_vetkeys",
+    "@icp-sdk/auth": "^5.0.0",
+    "@icp-sdk/core": "^5.0.0",
     "isomorphic-dompurify": "^2.25.0",
     "sirv-cli": "^1.0.0",
     "svelte-icons": "^2.1.0",

--- a/examples/encrypted_notes_dapp_vetkd/frontend/scripts/gen_bindings.sh
+++ b/examples/encrypted_notes_dapp_vetkd/frontend/scripts/gen_bindings.sh
@@ -7,3 +7,7 @@ rm -r frontend/src/declarations/encrypted_notes > /dev/null 2>&1 || true
 mkdir -p frontend/src/declarations/encrypted_notes
 mv src/declarations/encrypted_notes frontend/src/declarations
 rmdir -p src/declarations > /dev/null 2>&1 || true
+
+# Rewrite @dfinity/* imports to @icp-sdk/core/* in generated declarations
+find frontend/src/declarations -type f \( -name "*.ts" -o -name "*.js" \) -exec \
+  perl -i -pe 's|\@dfinity/agent|\@icp-sdk/core/agent|g; s|\@dfinity/principal|\@icp-sdk/core/principal|g; s|\@dfinity/candid|\@icp-sdk/core/candid|g' {} +

--- a/examples/encrypted_notes_dapp_vetkd/frontend/src/lib/actor.ts
+++ b/examples/encrypted_notes_dapp_vetkd/frontend/src/lib/actor.ts
@@ -4,7 +4,7 @@ import {
   ActorSubclass,
   HttpAgent,
   HttpAgentOptions,
-} from "@dfinity/agent";
+} from "@icp-sdk/core/agent";
 import {
   idlFactory,
   _SERVICE,

--- a/examples/encrypted_notes_dapp_vetkd/frontend/src/lib/note.ts
+++ b/examples/encrypted_notes_dapp_vetkd/frontend/src/lib/note.ts
@@ -1,6 +1,6 @@
 import type { EncryptedNote } from '../lib/backend';
 import type { CryptoService } from './crypto';
-import type { Principal } from '@dfinity/principal';
+import type { Principal } from '@icp-sdk/core/principal';
 
 export interface NoteModel {
   id: bigint;

--- a/examples/encrypted_notes_dapp_vetkd/frontend/src/store/auth.ts
+++ b/examples/encrypted_notes_dapp_vetkd/frontend/src/store/auth.ts
@@ -1,10 +1,10 @@
 import { get, writable } from "svelte/store";
 import { BackendActor, createActor } from "../lib/actor";
-import { AuthClient } from "@dfinity/auth-client";
+import { AuthClient } from "@icp-sdk/auth/client";
 import { CryptoService } from "../lib/crypto";
 import { addNotification, showError } from "./notifications";
 import { sleep } from "../lib/sleep";
-import type { JsonnableDelegationChain } from "@dfinity/identity/lib/cjs/identity/delegation";
+import type { JsonnableDelegationChain } from "@icp-sdk/core/identity";
 import { navigateTo } from "svelte-router-spa";
 
 export type AuthState =

--- a/examples/encrypted_notes_dapp_vetkd/frontend/tsconfig.json
+++ b/examples/encrypted_notes_dapp_vetkd/frontend/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "verbatimModuleSyntax": false
+  },
   "include": ["src/**/*"],
   "exclude": ["node_modules/*", "__sapper__/*", "public/*", "src/declarations/**/*"]
 }

--- a/examples/password_manager/frontend/package.json
+++ b/examples/password_manager/frontend/package.json
@@ -27,12 +27,9 @@
     "vite-plugin-environment": "^1.1.3"
   },
   "dependencies": {
-    "@dfinity/agent": "^2.3.0",
-    "@dfinity/auth-client": "^2.3.0",
-    "@dfinity/candid": "^2.3.0",
-    "@dfinity/identity": "^2.3.0",
-    "@dfinity/principal": "^2.3.0",
-    "@dfinity/vetkeys": "^0.3.0",
+    "@dfinity/vetkeys": "file:../../../frontend/ic_vetkeys",
+    "@icp-sdk/auth": "^5.0.0",
+    "@icp-sdk/core": "^5.0.0",
     "@popperjs/core": "^2.11.8",
     "@sveltejs/vite-plugin-svelte": "^3.0.2",
     "@tailwindcss/postcss": "^4.0.6",

--- a/examples/password_manager/frontend/src/components/EditPassword.svelte
+++ b/examples/password_manager/frontend/src/components/EditPassword.svelte
@@ -15,7 +15,7 @@
     import { auth } from "../store/auth";
     import Spinner from "./Spinner.svelte";
     import { onDestroy } from "svelte";
-    import { Principal } from "@dfinity/principal";
+    import { Principal } from "@icp-sdk/core/principal";
     import type { AccessRights } from "@dfinity/vetkeys/encrypted_maps";
 
     export let currentRoute = "";

--- a/examples/password_manager/frontend/src/components/NewPassword.svelte
+++ b/examples/password_manager/frontend/src/components/NewPassword.svelte
@@ -8,7 +8,7 @@
     import { addNotification, showError } from "../store/notifications";
     import Header from "./Header.svelte";
     import PasswordEditor from "./PasswordEditor.svelte";
-    import { Principal } from "@dfinity/principal";
+    import { Principal } from "@icp-sdk/core/principal";
 
     let creating = false;
     let vaultOwner =

--- a/examples/password_manager/frontend/src/components/Password.svelte
+++ b/examples/password_manager/frontend/src/components/Password.svelte
@@ -2,7 +2,7 @@
     import { type PasswordModel, summarize } from "../lib/password";
     import { link, location } from "svelte-spa-router";
     import { vaultsStore } from "../store/vaults";
-    import { Principal } from "@dfinity/principal";
+    import { Principal } from "@icp-sdk/core/principal";
     import { onDestroy } from "svelte";
     import Spinner from "./Spinner.svelte";
     import Header from "./Header.svelte";

--- a/examples/password_manager/frontend/src/components/SharingEditor.svelte
+++ b/examples/password_manager/frontend/src/components/SharingEditor.svelte
@@ -8,7 +8,7 @@
         vaultsStore,
     } from "../store/vaults";
     import { addNotification, showError } from "../store/notifications";
-    import { Principal } from "@dfinity/principal";
+    import { Principal } from "@icp-sdk/core/principal";
     import type { AccessRights } from "@dfinity/vetkeys/encrypted_maps";
 
     export let editedVault: VaultModel;

--- a/examples/password_manager/frontend/src/components/SidebarLayout.svelte
+++ b/examples/password_manager/frontend/src/components/SidebarLayout.svelte
@@ -4,7 +4,7 @@
     import GoDatabase from "svelte-icons/go/GoDatabase.svelte";
     import FaDoorOpen from "svelte-icons/fa/FaDoorOpen.svelte";
     import Disclaimer from "./Disclaimer.svelte";
-    import { Principal } from "@dfinity/principal";
+    import { Principal } from "@icp-sdk/core/principal";
     import { link } from "svelte-spa-router";
 </script>
 

--- a/examples/password_manager/frontend/src/components/Vault.svelte
+++ b/examples/password_manager/frontend/src/components/Vault.svelte
@@ -3,7 +3,7 @@
     import { link, location } from "svelte-spa-router";
     import { onDestroy } from "svelte";
     import { vaultsStore } from "../store/vaults";
-    import { Principal } from "@dfinity/principal";
+    import { Principal } from "@icp-sdk/core/principal";
     import Header from "./Header.svelte";
     import Spinner from "./Spinner.svelte";
     // @ts-expect-error: svelte-icons have some problems with ts declarations

--- a/examples/password_manager/frontend/src/lib/encrypted_maps.ts
+++ b/examples/password_manager/frontend/src/lib/encrypted_maps.ts
@@ -1,5 +1,5 @@
 import "./init.ts";
-import { HttpAgent, type HttpAgentOptions } from "@dfinity/agent";
+import { HttpAgent, type HttpAgentOptions } from "@icp-sdk/core/agent";
 import {
     DefaultEncryptedMapsClient,
     EncryptedMaps,

--- a/examples/password_manager/frontend/src/lib/password.ts
+++ b/examples/password_manager/frontend/src/lib/password.ts
@@ -1,4 +1,4 @@
-import type { Principal } from "@dfinity/principal";
+import type { Principal } from "@icp-sdk/core/principal";
 
 export interface PasswordModel {
     owner: Principal;

--- a/examples/password_manager/frontend/src/lib/vault.ts
+++ b/examples/password_manager/frontend/src/lib/vault.ts
@@ -1,4 +1,4 @@
-import type { Principal } from "@dfinity/principal";
+import type { Principal } from "@icp-sdk/core/principal";
 import type { PasswordModel } from "./password";
 import type { AccessRights } from "@dfinity/vetkeys/encrypted_maps";
 

--- a/examples/password_manager/frontend/src/store/auth.ts
+++ b/examples/password_manager/frontend/src/store/auth.ts
@@ -1,7 +1,7 @@
 import "../lib/init.ts";
 import { get, writable } from "svelte/store";
-import { AuthClient } from "@dfinity/auth-client";
-import type { JsonnableDelegationChain } from "@dfinity/identity/lib/cjs/identity/delegation";
+import { AuthClient } from "@icp-sdk/auth/client";
+import type { JsonnableDelegationChain } from "@icp-sdk/core/identity";
 import { replace } from "svelte-spa-router";
 import { createEncryptedMaps } from "../lib/encrypted_maps.js";
 import { EncryptedMaps } from "@dfinity/vetkeys/encrypted_maps";

--- a/examples/password_manager/frontend/src/store/vaults.ts
+++ b/examples/password_manager/frontend/src/store/vaults.ts
@@ -7,7 +7,7 @@ import {
     type AccessRights,
     EncryptedMaps,
 } from "@dfinity/vetkeys/encrypted_maps";
-import type { Principal } from "@dfinity/principal";
+import type { Principal } from "@icp-sdk/core/principal";
 
 export const vaultsStore = writable<
     | {

--- a/examples/password_manager_with_metadata/frontend/package.json
+++ b/examples/password_manager_with_metadata/frontend/package.json
@@ -36,12 +36,9 @@
         "vite-plugin-eslint": "^1.8.1"
     },
     "dependencies": {
-        "@dfinity/agent": "^2.3.0",
-        "@dfinity/auth-client": "^2.3.0",
-        "@dfinity/candid": "^2.3.0",
-        "@dfinity/identity": "^2.3.0",
-        "@dfinity/principal": "^2.3.0",
-        "@dfinity/vetkeys": "^0.3.0",
+        "@dfinity/vetkeys": "file:../../../frontend/ic_vetkeys",
+        "@icp-sdk/auth": "^5.0.0",
+        "@icp-sdk/core": "^5.0.0",
         "@sveltejs/vite-plugin-svelte": "^3.0.2",
         "daisyui": "^4.12.23",
         "save": "^2.9.0",

--- a/examples/password_manager_with_metadata/frontend/scripts/gen_bindings.sh
+++ b/examples/password_manager_with_metadata/frontend/scripts/gen_bindings.sh
@@ -9,3 +9,7 @@ rm -r frontend/src/declarations/password_manager_with_metadata > /dev/null 2>&1 
 mkdir -p frontend/src/declarations/password_manager_with_metadata
 mv src/declarations/password_manager_with_metadata frontend/src/declarations
 rmdir -p src/declarations > /dev/null 2>&1 || true
+
+# Rewrite @dfinity/* imports to @icp-sdk/core/* in generated declarations
+find frontend/src/declarations -type f \( -name "*.ts" -o -name "*.js" \) -exec \
+  perl -i -pe 's|\@dfinity/agent|\@icp-sdk/core/agent|g; s|\@dfinity/principal|\@icp-sdk/core/principal|g; s|\@dfinity/candid|\@icp-sdk/core/candid|g' {} +

--- a/examples/password_manager_with_metadata/frontend/src/components/EditPassword.svelte
+++ b/examples/password_manager_with_metadata/frontend/src/components/EditPassword.svelte
@@ -11,7 +11,7 @@
     import { auth } from "../store/auth";
     import Spinner from "./Spinner.svelte";
     import { onDestroy } from "svelte";
-    import { Principal } from "@dfinity/principal";
+    import { Principal } from "@icp-sdk/core/principal";
     import type { AccessRights } from "@dfinity/vetkeys/encrypted_maps";
 
     export let currentRoute = "";

--- a/examples/password_manager_with_metadata/frontend/src/components/NewPassword.svelte
+++ b/examples/password_manager_with_metadata/frontend/src/components/NewPassword.svelte
@@ -7,7 +7,7 @@
     import { addNotification, showError } from "../store/notifications";
     import Header from "./Header.svelte";
     import PasswordEditor from "./PasswordEditor.svelte";
-    import { Principal } from "@dfinity/principal";
+    import { Principal } from "@icp-sdk/core/principal";
 
     let creating = false;
     let vaultOwner =

--- a/examples/password_manager_with_metadata/frontend/src/components/Password.svelte
+++ b/examples/password_manager_with_metadata/frontend/src/components/Password.svelte
@@ -2,7 +2,7 @@
     import { type PasswordModel, summarize } from "../lib/password";
     import { link, location } from "svelte-spa-router";
     import { vaultsStore } from "../store/vaults";
-    import { Principal } from "@dfinity/principal";
+    import { Principal } from "@icp-sdk/core/principal";
     import { onDestroy } from "svelte";
     import Spinner from "./Spinner.svelte";
     import Header from "./Header.svelte";

--- a/examples/password_manager_with_metadata/frontend/src/components/SharingEditor.svelte
+++ b/examples/password_manager_with_metadata/frontend/src/components/SharingEditor.svelte
@@ -8,7 +8,7 @@
         vaultsStore,
     } from "../store/vaults";
     import { addNotification, showError } from "../store/notifications";
-    import { Principal } from "@dfinity/principal";
+    import { Principal } from "@icp-sdk/core/principal";
     import type { AccessRights } from "@dfinity/vetkeys/encrypted_maps";
 
     export let editedVault: VaultModel;

--- a/examples/password_manager_with_metadata/frontend/src/components/SidebarLayout.svelte
+++ b/examples/password_manager_with_metadata/frontend/src/components/SidebarLayout.svelte
@@ -7,7 +7,7 @@
     // @ts-expect-error: svelte-icons have some problems with ts declarations
     import FaDoorOpen from "svelte-icons/fa/FaDoorOpen.svelte";
     import Disclaimer from "./Disclaimer.svelte";
-    import { Principal } from "@dfinity/principal";
+    import { Principal } from "@icp-sdk/core/principal";
     import { link } from "svelte-spa-router";
 </script>
 

--- a/examples/password_manager_with_metadata/frontend/src/components/Vault.svelte
+++ b/examples/password_manager_with_metadata/frontend/src/components/Vault.svelte
@@ -3,7 +3,7 @@
     import { link, location } from "svelte-spa-router";
     import { onDestroy } from "svelte";
     import { vaultsStore } from "../store/vaults";
-    import { Principal } from "@dfinity/principal";
+    import { Principal } from "@icp-sdk/core/principal";
     import Header from "./Header.svelte";
     import Spinner from "./Spinner.svelte";
     // @ts-expect-error: svelte-icons have some problems with ts declarations

--- a/examples/password_manager_with_metadata/frontend/src/lib/encrypted_maps.ts
+++ b/examples/password_manager_with_metadata/frontend/src/lib/encrypted_maps.ts
@@ -1,5 +1,5 @@
 import "./init.ts";
-import { HttpAgent, type HttpAgentOptions } from "@dfinity/agent";
+import { HttpAgent, type HttpAgentOptions } from "@icp-sdk/core/agent";
 import {
     DefaultEncryptedMapsClient,
     EncryptedMaps,

--- a/examples/password_manager_with_metadata/frontend/src/lib/password.ts
+++ b/examples/password_manager_with_metadata/frontend/src/lib/password.ts
@@ -1,4 +1,4 @@
-import type { Principal } from "@dfinity/principal";
+import type { Principal } from "@icp-sdk/core/principal";
 import type { PasswordMetadata } from "../declarations/password_manager_with_metadata/password_manager_with_metadata.did";
 
 export interface PasswordModel {

--- a/examples/password_manager_with_metadata/frontend/src/lib/password_manager.ts
+++ b/examples/password_manager_with_metadata/frontend/src/lib/password_manager.ts
@@ -1,8 +1,8 @@
 import "./init.ts";
-import { type ActorSubclass, type HttpAgentOptions } from "@dfinity/agent";
+import { type ActorSubclass, type HttpAgentOptions } from "@icp-sdk/core/agent";
 import { EncryptedMaps } from "@dfinity/vetkeys/encrypted_maps";
 import { createEncryptedMaps } from "./encrypted_maps";
-import type { Principal } from "@dfinity/principal";
+import type { Principal } from "@icp-sdk/core/principal";
 import { createActor } from "../declarations/password_manager_with_metadata";
 import type { _SERVICE } from "../declarations/password_manager_with_metadata/password_manager_with_metadata.did";
 import { passwordFromContent, type PasswordModel } from "../lib/password";

--- a/examples/password_manager_with_metadata/frontend/src/lib/vault.ts
+++ b/examples/password_manager_with_metadata/frontend/src/lib/vault.ts
@@ -1,4 +1,4 @@
-import type { Principal } from "@dfinity/principal";
+import type { Principal } from "@icp-sdk/core/principal";
 import type { PasswordModel } from "./password";
 import type { AccessRights } from "@dfinity/vetkeys/encrypted_maps";
 

--- a/examples/password_manager_with_metadata/frontend/src/store/auth.ts
+++ b/examples/password_manager_with_metadata/frontend/src/store/auth.ts
@@ -1,7 +1,7 @@
 import "../lib/init.ts";
 import { get, writable } from "svelte/store";
-import { AuthClient } from "@dfinity/auth-client";
-import type { JsonnableDelegationChain } from "@dfinity/identity/lib/cjs/identity/delegation";
+import { AuthClient } from "@icp-sdk/auth/client";
+import type { JsonnableDelegationChain } from "@icp-sdk/core/identity";
 import { replace } from "svelte-spa-router";
 import {
     PasswordManager,

--- a/examples/password_manager_with_metadata/frontend/src/store/vaults.ts
+++ b/examples/password_manager_with_metadata/frontend/src/store/vaults.ts
@@ -4,7 +4,7 @@ import { type VaultModel } from "../lib/vault";
 import { auth } from "./auth";
 import { showError } from "./notifications";
 import { type AccessRights } from "@dfinity/vetkeys/encrypted_maps";
-import type { Principal } from "@dfinity/principal";
+import type { Principal } from "@icp-sdk/core/principal";
 import type { PasswordManager } from "../lib/password_manager";
 
 export const vaultsStore = writable<

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -80,7 +80,7 @@
     },
     "scripts": {
         "build": "tsc && vite build",
-        "prepare": "test -d dist || npm run build",
+        "prepare": "test -d dist || (npx vite --version >/dev/null 2>&1 && npm run build) || echo 'dist/ not found and vite not available — run npm install && npm run build in frontend/ic_vetkeys'",
         "coverage": "npm run test:deploy_all && export $(cat .test1.env .test2.env | xargs) && vitest run --coverage",
         "lint": "eslint",
         "make:docs": "mkdir -p $(git rev-parse --show-toplevel)/docs/key_manager && mkdir -p $(git rev-parse --show-toplevel)/docs/encrypted_maps && typedoc --out $(git rev-parse --show-toplevel)/docs",

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -57,13 +57,10 @@
     "module": "dist/lib/index.es.js",
     "typings": "dist/types/index.d.ts",
     "dependencies": {
-        "@dfinity/agent": "^3.4.0",
-        "@dfinity/candid": "^3.4.0",
-        "@dfinity/principal": "^3.4.0",
+        "@icp-sdk/core": "^5.0.0",
         "idb-keyval": "^6.2.1"
     },
     "devDependencies": {
-        "@dfinity/identity": "^3.4.0",
         "@eslint/js": "^9.22.0",
         "@types/node": "^24.0.4",
         "@vitest/coverage-v8": "^3.0.5",
@@ -83,7 +80,7 @@
     },
     "scripts": {
         "build": "tsc && vite build",
-        "prepare": "npm run build",
+        "prepare": "test -d dist || npm run build",
         "coverage": "npm run test:deploy_all && export $(cat .test1.env .test2.env | xargs) && vitest run --coverage",
         "lint": "eslint",
         "make:docs": "mkdir -p $(git rev-parse --show-toplevel)/docs/key_manager && mkdir -p $(git rev-parse --show-toplevel)/docs/encrypted_maps && typedoc --out $(git rev-parse --show-toplevel)/docs",

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -88,8 +88,6 @@
         "prettier-check": "prettier --check .",
         "test_utils": "vitest utils",
         "test": "npm run test:deploy_all && export $(cat .test1.env .test2.env | xargs) && vitest --sequence.concurrent",
-        "test:deploy_all": "npm run test:deploy_key_manager_canister && npm run test:deploy_encrypted_maps_canister",
-        "test:deploy_key_manager_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx start --clean --background; dfx deploy --argument '(\"dfx_test_key\")' ic_vetkeys_manager_canister && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env",
-        "test:deploy_encrypted_maps_canister": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx start --clean --background; dfx deploy --argument '(\"dfx_test_key\")' ic_vetkeys_encrypted_maps_canister && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"
+        "test:deploy_all": "cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_manager_canister && dfx stop 2>/dev/null; dfx start --clean --background && dfx deploy --argument '(\"dfx_test_key\")' ic_vetkeys_manager_canister && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test1.env && cd $(git rev-parse --show-toplevel)/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister && dfx deploy --argument '(\"dfx_test_key\")' ic_vetkeys_encrypted_maps_canister && grep CANISTER_ID .env > $(git rev-parse --show-toplevel)/frontend/ic_vetkeys/.test2.env"
     }
 }

--- a/frontend/ic_vetkeys/src/declarations/ic_vetkeys_encrypted_maps_canister/ic_vetkeys_encrypted_maps_canister.did.d.ts
+++ b/frontend/ic_vetkeys/src/declarations/ic_vetkeys_encrypted_maps_canister/ic_vetkeys_encrypted_maps_canister.did.d.ts
@@ -1,6 +1,6 @@
-import type { Principal } from '@dfinity/principal';
-import type { ActorMethod } from '@dfinity/agent';
-import type { IDL } from '@dfinity/candid';
+import type { Principal } from '@icp-sdk/core/principal';
+import type { ActorMethod } from '@icp-sdk/core/agent';
+import type { IDL } from '@icp-sdk/core/candid';
 
 export type AccessRights = { 'Read' : null } |
   { 'ReadWrite' : null } |

--- a/frontend/ic_vetkeys/src/declarations/ic_vetkeys_encrypted_maps_canister/index.d.ts
+++ b/frontend/ic_vetkeys/src/declarations/ic_vetkeys_encrypted_maps_canister/index.d.ts
@@ -3,9 +3,9 @@ import type {
   HttpAgentOptions,
   ActorConfig,
   Agent,
-} from "@dfinity/agent";
-import type { Principal } from "@dfinity/principal";
-import type { IDL } from "@dfinity/candid";
+} from "@icp-sdk/core/agent";
+import type { Principal } from "@icp-sdk/core/principal";
+import type { IDL } from "@icp-sdk/core/candid";
 
 import { _SERVICE } from './ic_vetkeys_encrypted_maps_canister.did';
 

--- a/frontend/ic_vetkeys/src/declarations/ic_vetkeys_encrypted_maps_canister/index.js
+++ b/frontend/ic_vetkeys/src/declarations/ic_vetkeys_encrypted_maps_canister/index.js
@@ -22,7 +22,8 @@ export const createActor = (canisterId, options = {}) => {
   }
 
   // Fetch root key for certificate validation during development
-  if (process.env.DFX_NETWORK !== "ic") {
+  // Skip if agent was provided by caller (they handle root key themselves)
+  if (!options.agent && process.env.DFX_NETWORK !== "ic") {
     agent.fetchRootKey().catch((err) => {
       console.warn(
         "Unable to fetch root key. Check to ensure that your local replica is running"

--- a/frontend/ic_vetkeys/src/declarations/ic_vetkeys_encrypted_maps_canister/index.js
+++ b/frontend/ic_vetkeys/src/declarations/ic_vetkeys_encrypted_maps_canister/index.js
@@ -1,4 +1,4 @@
-import { Actor, HttpAgent } from "@dfinity/agent";
+import { Actor, HttpAgent } from "@icp-sdk/core/agent";
 
 // Imports and re-exports candid interface
 import { idlFactory } from "./ic_vetkeys_encrypted_maps_canister.did.js";

--- a/frontend/ic_vetkeys/src/declarations/ic_vetkeys_manager_canister/ic_vetkeys_manager_canister.did.d.ts
+++ b/frontend/ic_vetkeys/src/declarations/ic_vetkeys_manager_canister/ic_vetkeys_manager_canister.did.d.ts
@@ -1,6 +1,6 @@
-import type { Principal } from '@dfinity/principal';
-import type { ActorMethod } from '@dfinity/agent';
-import type { IDL } from '@dfinity/candid';
+import type { Principal } from '@icp-sdk/core/principal';
+import type { ActorMethod } from '@icp-sdk/core/agent';
+import type { IDL } from '@icp-sdk/core/candid';
 
 export type AccessRights = { 'Read' : null } |
   { 'ReadWrite' : null } |

--- a/frontend/ic_vetkeys/src/declarations/ic_vetkeys_manager_canister/index.d.ts
+++ b/frontend/ic_vetkeys/src/declarations/ic_vetkeys_manager_canister/index.d.ts
@@ -3,9 +3,9 @@ import type {
   HttpAgentOptions,
   ActorConfig,
   Agent,
-} from "@dfinity/agent";
-import type { Principal } from "@dfinity/principal";
-import type { IDL } from "@dfinity/candid";
+} from "@icp-sdk/core/agent";
+import type { Principal } from "@icp-sdk/core/principal";
+import type { IDL } from "@icp-sdk/core/candid";
 
 import { _SERVICE } from './ic_vetkeys_manager_canister.did';
 

--- a/frontend/ic_vetkeys/src/declarations/ic_vetkeys_manager_canister/index.js
+++ b/frontend/ic_vetkeys/src/declarations/ic_vetkeys_manager_canister/index.js
@@ -22,7 +22,8 @@ export const createActor = (canisterId, options = {}) => {
   }
 
   // Fetch root key for certificate validation during development
-  if (process.env.DFX_NETWORK !== "ic") {
+  // Skip if agent was provided by caller (they handle root key themselves)
+  if (!options.agent && process.env.DFX_NETWORK !== "ic") {
     agent.fetchRootKey().catch((err) => {
       console.warn(
         "Unable to fetch root key. Check to ensure that your local replica is running"

--- a/frontend/ic_vetkeys/src/declarations/ic_vetkeys_manager_canister/index.js
+++ b/frontend/ic_vetkeys/src/declarations/ic_vetkeys_manager_canister/index.js
@@ -1,4 +1,4 @@
-import { Actor, HttpAgent } from "@dfinity/agent";
+import { Actor, HttpAgent } from "@icp-sdk/core/agent";
 
 // Imports and re-exports candid interface
 import { idlFactory } from "./ic_vetkeys_manager_canister.did.js";

--- a/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps_canister.test.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps_canister.test.ts
@@ -1,8 +1,8 @@
-import { HttpAgent } from "@dfinity/agent";
+import { HttpAgent } from "@icp-sdk/core/agent";
 import { DefaultEncryptedMapsClient } from "./encrypted_maps_canister";
 import { expect, test } from "vitest";
 import fetch from "isomorphic-fetch";
-import { Ed25519KeyIdentity } from "@dfinity/identity";
+import { Ed25519KeyIdentity } from "@icp-sdk/core/identity";
 import { EncryptedMaps } from "./index";
 import { randomBytes } from "node:crypto";
 

--- a/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps_canister.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps_canister.ts
@@ -1,5 +1,5 @@
-import { Principal } from "@dfinity/principal";
-import { ActorSubclass, HttpAgent } from "@dfinity/agent";
+import { Principal } from "@icp-sdk/core/principal";
+import { ActorSubclass, HttpAgent } from "@icp-sdk/core/agent";
 import { createActor } from "../declarations/ic_vetkeys_encrypted_maps_canister/index";
 import {
     _SERVICE as _DEFAULT_ENCRYPTED_MAPS_SERVICE,

--- a/frontend/ic_vetkeys/src/encrypted_maps/index.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/index.ts
@@ -4,7 +4,7 @@
  * @description See { @link EncryptedMaps }.
  */
 
-import { Principal } from "@dfinity/principal";
+import { Principal } from "@icp-sdk/core/principal";
 import { get, set } from "idb-keyval";
 import {
     TransportSecretKey,

--- a/frontend/ic_vetkeys/src/key_manager/index.ts
+++ b/frontend/ic_vetkeys/src/key_manager/index.ts
@@ -5,7 +5,7 @@
  *
  */
 
-import { Principal } from "@dfinity/principal";
+import { Principal } from "@icp-sdk/core/principal";
 import {
     TransportSecretKey,
     EncryptedVetKey,

--- a/frontend/ic_vetkeys/src/key_manager/key_manager_canister.test.ts
+++ b/frontend/ic_vetkeys/src/key_manager/key_manager_canister.test.ts
@@ -1,5 +1,5 @@
-import { HttpAgent } from "@dfinity/agent";
-import { Ed25519KeyIdentity } from "@dfinity/identity";
+import { HttpAgent } from "@icp-sdk/core/agent";
+import { Ed25519KeyIdentity } from "@icp-sdk/core/identity";
 import fetch from "isomorphic-fetch";
 import { expect, test } from "vitest";
 import { KeyManager } from "./index";

--- a/frontend/ic_vetkeys/src/key_manager/key_manager_canister.ts
+++ b/frontend/ic_vetkeys/src/key_manager/key_manager_canister.ts
@@ -1,5 +1,5 @@
-import { Principal } from "@dfinity/principal";
-import { ActorSubclass, HttpAgent } from "@dfinity/agent";
+import { Principal } from "@icp-sdk/core/principal";
+import { ActorSubclass, HttpAgent } from "@icp-sdk/core/agent";
 import { createActor } from "../declarations/ic_vetkeys_manager_canister/index.js";
 import {
     _SERVICE as _DEFAULT_KEY_MANAGER_SERVICE,

--- a/frontend/ic_vetkeys/src/utils/utils.ts
+++ b/frontend/ic_vetkeys/src/utils/utils.ts
@@ -5,7 +5,7 @@ import { hash_to_field, Opts } from "@noble/curves/abstract/hash-to-curve";
 import { shake256 } from "@noble/hashes/sha3";
 import { hkdf } from "@noble/hashes/hkdf";
 import { sha256 } from "@noble/hashes/sha256";
-import type { Principal } from "@dfinity/principal";
+import type { Principal } from "@icp-sdk/core/principal";
 
 export type G1Point = ProjPointType<Fp>;
 export type G2Point = ProjPointType<Fp2>;


### PR DESCRIPTION
Migrate all frontend code from deprecated @dfinity/{agent,principal,candid,identity} to @icp-sdk/core/{agent,principal,candid,identity} and @dfinity/auth-client to @icp-sdk/auth/client.

- Main library (frontend/ic_vetkeys): update deps and all source imports
- All 7 example frontends: update deps, source imports, and Svelte components
- Point example @dfinity/vetkeys deps to local build (file:../../../frontend/ic_vetkeys)
- Fix encrypted_notes tsconfig for moduleResolution: bundler compatibility
- Update prepare script to skip rebuild when dist/ exists