### PR TITLE
ci: update GitHub Actions workflows for icp-cli

### DIFF
--- a/.github/workflows/backend-motoko.yml
+++ b/.github/workflows/backend-motoko.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Run MOPS Test Linux
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cd backend/mo/ic_vetkeys
@@ -51,6 +53,8 @@ jobs:
       - name: Provision Darwin
         run: bash .github/workflows/provision-darwin.sh
       - name: Run MOPS Test Darwin
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cd backend/mo/ic_vetkeys

--- a/.github/workflows/examples-basic-bls-signing.yml
+++ b/.github/workflows/examples-basic-bls-signing.yml
@@ -15,8 +15,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-env:
-  DFX_VERSION: 0.29.1
 jobs:
   examples-basic-bls-signing-rust-darwin:
     runs-on: macos-15
@@ -24,20 +22,22 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Darwin
-        run: |
-          bash .github/workflows/provision-darwin.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Darwin
+        run: |
+          bash .github/workflows/provision-darwin.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Basic BLS Signing Rust Darwin
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cargo install candid-extractor
           pushd examples/basic_bls_signing/rust
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint
   examples-basic-bls-signing-rust-linux:
@@ -46,19 +46,21 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Linux
-        run: bash .github/workflows/provision-linux.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Linux
+        run: bash .github/workflows/provision-linux.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Basic BLS Signing Rust Linux
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cargo install candid-extractor
           pushd examples/basic_bls_signing/rust
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint
   examples-basic-bls-signing-motoko-darwin:
@@ -67,20 +69,22 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Darwin
-        run: |
-          bash .github/workflows/provision-darwin.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Darwin
+        run: |
+          bash .github/workflows/provision-darwin.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Basic BLS Signing Motoko Darwin
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cargo install candid-extractor
           pushd examples/basic_bls_signing/motoko
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint
   examples-basic-bls-signing-motoko-linux:
@@ -89,18 +93,20 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Linux
-        run: bash .github/workflows/provision-linux.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Linux
+        run: bash .github/workflows/provision-linux.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Basic BLS Signing Motoko Linux
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cargo install candid-extractor
           pushd examples/basic_bls_signing/motoko
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint

--- a/.github/workflows/examples-basic-ibe.yml
+++ b/.github/workflows/examples-basic-ibe.yml
@@ -14,8 +14,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-env:
-  DFX_VERSION: 0.29.1
 jobs:
   examples-basic-ibe-rust-darwin:
     runs-on: macos-15
@@ -23,20 +21,22 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Darwin
-        run: |
-          bash .github/workflows/provision-darwin.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Darwin
+        run: |
+          bash .github/workflows/provision-darwin.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Basic IBE Rust Darwin
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cargo install candid-extractor
           pushd examples/basic_ibe/rust
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint
   examples-basic-ibe-rust-linux:
@@ -45,19 +45,21 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Linux
-        run: bash .github/workflows/provision-linux.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Linux
+        run: bash .github/workflows/provision-linux.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Basic IBE Rust Linux
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cargo install candid-extractor
           pushd examples/basic_ibe/rust
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint
   examples-basic-ibe-motoko-darwin:
@@ -66,20 +68,22 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Darwin
-        run: |
-          bash .github/workflows/provision-darwin.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Darwin
+        run: |
+          bash .github/workflows/provision-darwin.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Basic IBE Motoko Darwin
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cargo install candid-extractor
           pushd examples/basic_ibe/motoko
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint
   examples-basic-ibe-motoko-linux:
@@ -88,18 +92,20 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Linux
-        run: bash .github/workflows/provision-linux.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Linux
+        run: bash .github/workflows/provision-linux.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Basic IBE Motoko Linux
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cargo install candid-extractor
           pushd examples/basic_ibe/motoko
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint

--- a/.github/workflows/examples-basic-timelock-ibe.yml
+++ b/.github/workflows/examples-basic-timelock-ibe.yml
@@ -22,20 +22,22 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Darwin
-        run: |
-          bash .github/workflows/provision-darwin.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Darwin
+        run: |
+          bash .github/workflows/provision-darwin.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Basic Timelock IBE Darwin
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cargo install candid-extractor
           pushd examples/basic_timelock_ibe
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint
   examples-basic-timelock-ibe-rust-linux:
@@ -44,18 +46,20 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Linux
-        run: bash .github/workflows/provision-linux.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Linux
+        run: bash .github/workflows/provision-linux.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Basic Timelock IBE Linux
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cargo install candid-extractor
           pushd examples/basic_timelock_ibe
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint

--- a/.github/workflows/examples-encrypted-chat.yml
+++ b/.github/workflows/examples-encrypted-chat.yml
@@ -20,6 +20,9 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
@@ -37,6 +40,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/examples-encrypted-notes-dapp.yml
+++ b/.github/workflows/examples-encrypted-notes-dapp.yml
@@ -14,8 +14,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-env:
-  DFX_VERSION: 0.29.1
 jobs:
   examples-encrypted-notes-dapp-rust-darwin:
     runs-on: macos-15
@@ -23,71 +21,79 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Darwin
-        run: |
-          bash .github/workflows/provision-darwin.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Darwin
+        run: |
+          bash .github/workflows/provision-darwin.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Encrypted Notes Dapp VetKD Darwin
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cd examples/encrypted_notes_dapp_vetkd/rust
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
   examples-encrypted-notes-dapp-rust-linux:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Linux
-        run: bash .github/workflows/provision-linux.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Linux
+        run: bash .github/workflows/provision-linux.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Encrypted Notes Dapp VetKD Linux
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cd examples/encrypted_notes_dapp_vetkd/rust
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
   examples-encrypted-notes-dapp-motoko-darwin:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Darwin
-        run: |
-          bash .github/workflows/provision-darwin.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Darwin
+        run: |
+          bash .github/workflows/provision-darwin.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Encrypted Notes Dapp VetKD Darwin
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cd examples/encrypted_notes_dapp_vetkd/motoko
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
   examples-encrypted-notes-dapp-motoko-linux:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Linux
-        run: bash .github/workflows/provision-linux.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Linux
+        run: bash .github/workflows/provision-linux.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Encrypted Notes Dapp VetKD Linux
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cd examples/encrypted_notes_dapp_vetkd/motoko
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy

--- a/.github/workflows/examples-password-manager-with-metadata.yml
+++ b/.github/workflows/examples-password-manager-with-metadata.yml
@@ -16,8 +16,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-env:
-  DFX_VERSION: 0.29.1
 jobs:
   examples-password-manager-with-metadata-rust-darwin:
     runs-on: macos-15
@@ -25,20 +23,22 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Darwin
-        run: |
-          bash .github/workflows/provision-darwin.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Darwin
+        run: |
+          bash .github/workflows/provision-darwin.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Password Manager With Metadata Darwin
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cargo install candid-extractor
           cd examples/password_manager_with_metadata/rust
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint
   examples-password-manager-with-metadata-rust-linux:
@@ -47,19 +47,21 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Linux
-        run: bash .github/workflows/provision-linux.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Linux
+        run: bash .github/workflows/provision-linux.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Password Manager With Metadata Linux
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cargo install candid-extractor
           cd examples/password_manager_with_metadata/rust
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint
   examples-password-manager-with-metadata-motoko-darwin:
@@ -68,20 +70,22 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Darwin
-        run: |
-          bash .github/workflows/provision-darwin.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Darwin
+        run: |
+          bash .github/workflows/provision-darwin.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Password Manager With Metadata Darwin
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cargo install candid-extractor
           cd examples/password_manager_with_metadata/motoko
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint
   examples-password-manager-with-metadata-motoko-linux:
@@ -90,18 +94,20 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Linux
-        run: bash .github/workflows/provision-linux.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Linux
+        run: bash .github/workflows/provision-linux.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Password Manager With Metadata Linux
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cargo install candid-extractor
           cd examples/password_manager_with_metadata/motoko
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint

--- a/.github/workflows/examples-password-manager.yml
+++ b/.github/workflows/examples-password-manager.yml
@@ -16,8 +16,6 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-env:
-  DFX_VERSION: 0.29.1
 jobs:
   examples-password-manager-rust-darwin:
     runs-on: macos-15
@@ -25,19 +23,21 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Darwin
-        run: |
-          bash .github/workflows/provision-darwin.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Darwin
+        run: |
+          bash .github/workflows/provision-darwin.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Password Manager Darwin
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cd examples/password_manager/rust
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint
   examples-password-manager-rust-linux:
@@ -46,18 +46,20 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Linux
-        run: bash .github/workflows/provision-linux.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Linux
+        run: bash .github/workflows/provision-linux.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Password Manager Linux
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cd examples/password_manager/rust
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint
   examples-password-manager-motoko-darwin:
@@ -66,19 +68,21 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Darwin
-        run: |
-          bash .github/workflows/provision-darwin.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Darwin
+        run: |
+          bash .github/workflows/provision-darwin.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Password Manager Darwin
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cd examples/password_manager/motoko
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint
   examples-password-manager-motoko-linux:
@@ -87,17 +91,19 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-      - name: Provision Linux
-        run: bash .github/workflows/provision-linux.sh
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+      - name: Provision Linux
+        run: bash .github/workflows/provision-linux.sh
       - name: Install workspace dependencies
         run: npm install
       - name: Deploy Password Manager Linux
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           cd examples/password_manager/motoko
-          dfx start --background && dfx deploy
+          icp network start -d && icp deploy
           cd frontend
           npm run lint

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -11,7 +11,7 @@ on:
       - backend/**/canisters/**
       - package.json
       - package-lock.json
-      - .github/workflows/frontend_ic_vetkeys.yml
+      - .github/workflows/frontend.yml
       - .github/workflows/provision-darwin.sh
       - .github/workflows/provision-linux.sh
 concurrency:
@@ -24,9 +24,14 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Frontend Tests and Lint
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           npm install
@@ -40,10 +45,15 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh
       - name: Frontend Tests and Lint
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eExuo pipefail
           npm install

--- a/.github/workflows/provision-darwin.sh
+++ b/.github/workflows/provision-darwin.sh
@@ -5,29 +5,8 @@ set -ex
 # Enter temporary directory.
 pushd /tmp
 
-# Install Node.
-brew install nodejs
-
-# Install DFINITY SDK.
-curl --location --output install-dfx.sh "https://raw.githubusercontent.com/dfinity/sdk/master/public/install-dfxvm.sh"
-DFX_VERSION=${DFX_VERSION:=0.26.1} DFXVM_INIT_YES=true bash install-dfx.sh
-rm install-dfx.sh
-echo "$HOME/Library/Application Support/org.dfinity.dfx/bin" >> $GITHUB_PATH
-source "$HOME/Library/Application Support/org.dfinity.dfx/env"
-dfx cache install
-
-# check the current ic-commit found in the main branch, check if it differs from the one in this PR branch
-# if so, update the  dfx cache with the latest ic artifacts
-if [ -f "${GITHUB_WORKSPACE}/.ic-commit" ]; then
-    stable_sha=$(curl https://raw.githubusercontent.com/dfinity/examples/master/.ic-commit)
-    current_sha=$(sed <"$GITHUB_WORKSPACE/.ic-commit" 's/#.*$//' | sed '/^$/d')
-    arch="x86_64-darwin"
-    if [ "$current_sha" != "$stable_sha" ]; then
-      export current_sha
-      export arch
-      sh "$GITHUB_WORKSPACE/.github/workflows/update-dfx-cache.sh"
-    fi
-fi
+# Install icp-cli (requires Node.js >=22, set up via actions/setup-node in the workflow).
+npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm ic-mops
 
 # Install rust
 curl --location --output install-rustup.sh "https://sh.rustup.rs"

--- a/.github/workflows/provision-linux.sh
+++ b/.github/workflows/provision-linux.sh
@@ -5,32 +5,12 @@ set -ex
 # Enter temporary directory.
 pushd /tmp
 
-# Install Node.
-sudo apt-get install nodejs
-
-# Install DFINITY SDK.
-wget --output-document install-dfx.sh "https://raw.githubusercontent.com/dfinity/sdk/master/public/install-dfxvm.sh"
-DFX_VERSION=${DFX_VERSION:=0.26.1} DFXVM_INIT_YES=true bash install-dfx.sh
-rm install-dfx.sh
-echo "$HOME/.local/share/dfx/bin" >>$GITHUB_PATH
-source "$HOME/.local/share/dfx/env"
-dfx cache install
-# check the current ic-commit found in the main branch, check if it differs from the one in this PR branch
-# if so, update the  dfx cache with the latest ic artifacts
-if [ -f "${GITHUB_WORKSPACE}/.ic-commit" ]; then
-  stable_sha=$(curl https://raw.githubusercontent.com/dfinity/examples/master/.ic-commit)
-  current_sha=$(sed <"$GITHUB_WORKSPACE/.ic-commit" 's/#.*$//' | sed '/^$/d')
-  arch="x86_64-linux"
-  if [ "$current_sha" != "$stable_sha" ]; then
-    export current_sha
-    export arch
-    sh "$GITHUB_WORKSPACE/.github/workflows/update-dfx-cache.sh"
-  fi
-fi
+# Install icp-cli (requires Node.js >=22, set up via actions/setup-node in the workflow).
+npm install -g @icp-sdk/icp-cli @icp-sdk/ic-wasm ic-mops
 
 # Install rust
 wget --output-document install-rustup.sh "https://sh.rustup.rs"
-sudo bash install-rustup.sh -y
+bash install-rustup.sh -y
 rustup target add wasm32-unknown-unknown
 
 # Set environment variables.

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ target/
 .idea/
 
 **/.dfx/*
+**/.icp/cache
 **/deps/*
 backend/**/declarations
 examples/**/declarations


### PR DESCRIPTION
Update all CI workflows to use icp-cli instead of dfx, add ICP_CLI_GITHUB_TOKEN for rate limiting, and add Node.js 22 setup.

- Replace dfx commands with icp equivalents in all example workflows
- Add ICP_CLI_GITHUB_TOKEN env var to icp steps
- Add actions/setup-node for Node.js 22
- Simplify provision scripts (remove dfx installation)
- Add .icp to .gitignore