### PR TITLE
chore: release Motoko ic-vetkeys v0.5.0

### DIFF
--- a/backend/mo/ic_vetkeys/CHANGELOG.md
+++ b/backend/mo/ic_vetkeys/CHANGELOG.md
@@ -6,10 +6,10 @@
 
 - Migrated the library from the deprecated `mo:base` to `mo:core` 2.4.0. Public types such as `KeyManagerState` and `EncryptedMapsState` now reference `mo:core/pure/Map.Map` instead of `mo:base/OrderedMap`; downstream code that constructs or inspects these state records must be updated accordingly.
 - Now requires `moc` 1.6.0 and `mo:core` 2.4.0, declared via the new `[toolchain]` section in `mops.toml`.
-
+ 
 ### Changed
 
-- Internal refactors to align with `mo:core` conventions: `Buffer` → `List`, `Debug.trap` → `Runtime.trap`, `Array.subArray` → `Array.sliceToArray`, and modern Motoko style applied via `mops check --fix` (dot notation, removal of redundant type instantiations and implicit arguments).
+- Internal refactoring to align with `mo:core` conventions and modern Motoko style.
 
 ## [0.4.0] - 2025-09-29
 

--- a/backend/mo/ic_vetkeys/CHANGELOG.md
+++ b/backend/mo/ic_vetkeys/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [0.5.0] - 2026-04-22
+
+### Breaking changes
+
+- Migrated the library from the deprecated `mo:base` to `mo:core` 2.4.0. Public types such as `KeyManagerState` and `EncryptedMapsState` now reference `mo:core/pure/Map.Map` instead of `mo:base/OrderedMap`; downstream code that constructs or inspects these state records must be updated accordingly.
+- Now requires `moc` 1.6.0 and `mo:core` 2.4.0, declared via the new `[toolchain]` section in `mops.toml`.
+
+### Changed
+
+- Internal refactors to align with `mo:core` conventions: `Buffer` → `List`, `Debug.trap` → `Runtime.trap`, `Array.subArray` → `Array.sliceToArray`, and modern Motoko style applied via `mops check --fix` (dot notation, removal of redundant type instantiations and implicit arguments).
+
 ## [0.4.0] - 2025-09-29
 
 ### Breaking changes

--- a/backend/mo/ic_vetkeys/mops.toml
+++ b/backend/mo/ic_vetkeys/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-vetkeys"
-version = "0.4.0"
+version = "0.5.0"
 repository = "https://github.com/dfinity/vetkeys/backend/mo/ic_vetkeys"
 description = "A set of tools designed to help canister developers integrate vetKeys into their Internet Computer (ICP) applications"
 keywords = [


### PR DESCRIPTION
Bumps the Motoko ic-vetkeys to 0.5.0 and updates the CHANGELOG.md.