### PR TITLE
fix: replace deprecated @noble/curves and @noble/hashes APIs

### DIFF
--- a/frontend/ic_vetkeys/CHANGELOG.md
+++ b/frontend/ic_vetkeys/CHANGELOG.md
@@ -30,6 +30,12 @@
 
 - Make `DerivedKeyMaterial.deriveAesGcmCryptoKey` `@internal`.
 
+### Fixed
+
+- Updated `@noble/curves` and `@noble/hashes` usages to current non-deprecated APIs.
+  The exported `G1Point` and `G2Point` types now resolve to `WeierstrassPoint` instead
+  of the deprecated `ProjPointType` alias.
+
 ## [0.4.0] - 2025-08-04
 
 ### Added

--- a/frontend/ic_vetkeys/src/encrypted_maps/index.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/index.ts
@@ -40,32 +40,6 @@ export type {
  * - **Access Rights** should be carefully managed to prevent unauthorized access.
  * - VetKeys should be decrypted **only in trusted environments** such as user browsers to prevent leaks.
  *
- * @example
- * ```ts
- * import { EncryptedMaps } from "@dfinity/vetkeys/encrypted_maps";
- *
- * // Initialize the EncryptedMaps Client
- * const encryptedMaps = new EncryptedMaps(encryptedMapsClientInstance);
- *
- * // Retrieve shared maps
- * const sharedMaps = await encryptedMaps.getAccessibleSharedMapNames();
- *
- * const mapOwner = Principal.fromText("aaaaa-aa");
- * const mapName = "passwords";
- * const mapKey = "email_account";
- *
- * // Store an encrypted value
- * const value = new TextEncoder().encode("my_secure_password");
- * const result = await encryptedMaps.setValue(mapOwner, mapName, mapKey, value);
- *
- * // Retrieve a stored value
- * const storedValue = await encryptedMaps.getValue(mapOwner, mapName, mapKey);
- *
- * // Manage user access rights
- * const user = Principal.fromText("bbbbbb-bb");
- * const accessRights = { ReadWrite: null };
- * const result = await encryptedMaps.setUserRights(mapOwner, mapName, user, accessRights);
- * ```
  */
 export class EncryptedMaps {
     /**
@@ -459,7 +433,7 @@ export class EncryptedMaps {
      *
      * @example
      * ```ts
-     * const userRights = await encryptedMaps.get_user_rights(owner, mapName, user);
+     * const userRights = await encryptedMaps.getUserRights(owner, mapName, user);
      * console.log("User Access Rights:", userRights);
      * ```
      *
@@ -514,7 +488,7 @@ export class EncryptedMaps {
      *
      * @example
      * ```ts
-     * const removalResult = await encryptedMaps.remove_user(owner, mapName, user);
+     * const removalResult = await encryptedMaps.removeUser(owner, mapName, user);
      * console.log("User Removed:", removalResult);
      * ```
      *

--- a/frontend/ic_vetkeys/src/index.ts
+++ b/frontend/ic_vetkeys/src/index.ts
@@ -3,57 +3,6 @@
  *
  * @description Provides frontend utilities for the low-level use of Verifiably Encrypted Threshold Keys (VetKeys) on the Internet Computer (IC) such as decryption of encrypted VetKeys, identity based encryption (IBE), and symmetric key derivation from a VetKey.
  *
- * ## Usage Example: IBE
- *
- * This example demonstrates the complete flow from key generation to message encryption and decryption:
- *
- * ```ts
- * import {
- *   TransportSecretKey,
- *   DerivedPublicKey,
- *   EncryptedKey,
- *   VetKey,
- *   IbeCiphertext,
- *   IbeIdentity,
- *   IbeSeed,
- * } from "ic_vetkd_sdk_utils";
- *
- * // 1. Generate a Transport Secret Key for decrypting VetKD-derived keys
- * const tsk = TransportSecretKey.random();
- *
- * // 2. Load a Derived Public Key (obtained from the IC)
- * const dpkBytes = new Uint8Array([...]); // Replace with actual bytes from IC
- * const dpk = DerivedPublicKey.deserialize(dpkBytes);
- *
- * // 3. Perform second-stage key derivation with a specific input, e.g., other user's principal as bytes
- * const input = new Uint8Array([1, 2, 3]); // Your application-specific input
- * const derivedKey = dpk.deriveKey(input);
- * console.log("Derived Public Key:", derivedKey.publicKeyBytes());
- *
- * // 4. Decrypt a VetKey using the transport secret key
- * const encKeyBytes = new Uint8Array([...]); // Replace with encrypted key from IC
- * const encryptedKey = new EncryptedKey(encKeyBytes);
- * const vetKey = encryptedKey.decryptAndVerify(tsk, dpk, input);
- * console.log('Decrypted VetKey:', vetKey.signatureBytes());
- *
- * // 5. Use Identity-Based Encryption to encrypt and decrypt a message
- * const message = new TextEncoder().encode("Secret message");
- *
- * // 6. Encrypt the message
- * const ciphertext = IbeCiphertext.encrypt(
- *   dpk,
- *   IbeIdentity.fromBytes(input),
- *   message,
- *   IbeSeed.random()
- * );
- * const serializedCiphertext = ciphertext.serialize();
- *
- * // 7. Decrypt the message
- * const deserializedCiphertext = IbeCiphertext.deserialize(serializedCiphertext);
- * const decryptedMessage = deserializedCiphertext.decrypt(vetKey);
- * console.log("Decrypted Message:", new TextDecoder().decode(decryptedMessage));
- * ```
- *
  * ## Security Considerations
  *
  * - **Keep Transport Secret Keys Private:** Never expose the transport secret key as it is required for decrypting VetKeys.

--- a/frontend/ic_vetkeys/src/key_manager/index.ts
+++ b/frontend/ic_vetkeys/src/key_manager/index.ts
@@ -38,26 +38,6 @@ export type {
  * - **Access Rights** should be carefully managed to prevent unauthorized access.
  * - VetKeys should be decrypted **only in trusted environments** such as user browsers to prevent leaks.
  *
- * @example
- * ```ts
- * import { KeyManager } from "@dfinity/vetkeys/key_manager";
- *
- * // Initialize the KeyManager
- * const keyManager = new KeyManager(keyManagerClientInstance);
- *
- * // Retrieve shared keys
- * const sharedKeys = await keyManager.getAccessibleSharedKeyIds();
- *
- * // Request and decrypt a VetKey
- * const keyOwner = Principal.fromText("aaaaa-aa");
- * const vetkeyName = "my_secure_key";
- * const vetkey = await keyManager.getVetKey(keyOwner, vetkeyName);
- *
- * // Manage user access rights
- * const user = Principal.fromText("bbbbbb-bb");
- * const accessRights = { ReadWrite: null };
- * const result = await keyManager.setUserRights(keyOwner, vetkeyName, user, accessRights);
- * ```
  */
 export class KeyManager {
     /**
@@ -224,7 +204,7 @@ export class KeyManager {
      *
      * @example
      * ```ts
-     * const userRights = await keyManager.get_user_rights(owner, keyName, user);
+     * const userRights = await keyManager.getUserRights(owner, keyName, user);
      * console.log("User Access Rights:", userRights);
      * ```
      *

--- a/frontend/ic_vetkeys/src/utils/utils.ts
+++ b/frontend/ic_vetkeys/src/utils/utils.ts
@@ -552,7 +552,6 @@ export class VetKey {
     constructor(pt: G1Point) {
         this.#pt = pt;
 
-
         this.#bytes = pt.toBytes(true) as Uint8Array<ArrayBuffer>;
     }
 }

--- a/frontend/ic_vetkeys/src/utils/utils.ts
+++ b/frontend/ic_vetkeys/src/utils/utils.ts
@@ -1,14 +1,13 @@
 import { bls12_381 } from "@noble/curves/bls12-381";
-import { ProjPointType } from "@noble/curves/abstract/weierstrass";
+import { WeierstrassPoint } from "@noble/curves/abstract/weierstrass";
 import { Fp, Fp2, Fp12 } from "@noble/curves/abstract/tower";
-import { hash_to_field, Opts } from "@noble/curves/abstract/hash-to-curve";
 import { shake256 } from "@noble/hashes/sha3";
 import { hkdf } from "@noble/hashes/hkdf";
-import { sha256 } from "@noble/hashes/sha256";
+import { sha256 } from "@noble/hashes/sha2";
 import type { Principal } from "@icp-sdk/core/principal";
 
-export type G1Point = ProjPointType<Fp>;
-export type G2Point = ProjPointType<Fp2>;
+export type G1Point = WeierstrassPoint<Fp>;
+export type G2Point = WeierstrassPoint<Fp2>;
 
 const G1_BYTES = 48;
 const G2_BYTES = 96;
@@ -28,7 +27,7 @@ export class TransportSecretKey {
      * Create a random transport secret key
      */
     static random() {
-        return new TransportSecretKey(bls12_381.utils.randomPrivateKey());
+        return new TransportSecretKey(bls12_381.utils.randomSecretKey());
     }
 
     /**
@@ -50,7 +49,7 @@ export class TransportSecretKey {
      * sent to the IC
      */
     publicKeyBytes(): Uint8Array {
-        return this.#pk.toRawBytes(true);
+        return this.#pk.toBytes(true);
     }
 
     /**
@@ -67,7 +66,9 @@ export class TransportSecretKey {
      */
     private constructor(sk: Uint8Array) {
         this.#sk = sk;
-        const pk = bls12_381.G1.ProjectivePoint.fromPrivateKey(this.#sk);
+        const pk = bls12_381.G1.Point.BASE.multiply(
+            bls12_381.G1.Point.Fn.fromBytes(this.#sk),
+        );
         this.#pk = pk;
     }
 }
@@ -85,7 +86,7 @@ export function isValidTransportPublicKey(tpk: Uint8Array): boolean {
     }
 
     try {
-        bls12_381.G1.ProjectivePoint.fromHex(tpk);
+        bls12_381.G1.Point.fromHex(tpk);
         return true;
     } catch {
         return false;
@@ -157,7 +158,7 @@ export class MasterPublicKey {
      * the `vetkd_public_key` management canister interface.
      */
     static deserialize(bytes: Uint8Array): MasterPublicKey {
-        return new MasterPublicKey(bls12_381.G2.ProjectivePoint.fromHex(bytes));
+        return new MasterPublicKey(bls12_381.G2.Point.fromHex(bytes));
     }
 
     /**
@@ -179,7 +180,7 @@ export class MasterPublicKey {
             ...prefixWithLen(canisterId),
         ]);
         const offset = hashToScalar(randomOracleInput, dst);
-        const g2offset = bls12_381.G2.ProjectivePoint.BASE.multiply(offset);
+        const g2offset = bls12_381.G2.Point.BASE.multiply(offset);
         return new DerivedPublicKey(this.#pk.add(g2offset));
     }
 
@@ -187,7 +188,7 @@ export class MasterPublicKey {
      * Return the bytestring encoding of the master public key
      */
     publicKeyBytes(): Uint8Array {
-        return this.#pk.toRawBytes(true);
+        return this.#pk.toBytes(true);
     }
 
     /**
@@ -274,9 +275,7 @@ export class DerivedPublicKey {
      * the `vetkd_public_key` management canister interface.
      */
     static deserialize(bytes: Uint8Array): DerivedPublicKey {
-        return new DerivedPublicKey(
-            bls12_381.G2.ProjectivePoint.fromHex(bytes),
-        );
+        return new DerivedPublicKey(bls12_381.G2.Point.fromHex(bytes));
     }
 
     /**
@@ -306,7 +305,7 @@ export class DerivedPublicKey {
                 ...prefixWithLen(context),
             ]);
             const offset = hashToScalar(randomOracleInput, dst);
-            const g2offset = bls12_381.G2.ProjectivePoint.BASE.multiply(offset);
+            const g2offset = bls12_381.G2.Point.BASE.multiply(offset);
             return new DerivedPublicKey(this.getPoint().add(g2offset));
         }
     }
@@ -319,7 +318,7 @@ export class DerivedPublicKey {
      * these bytes are used by anyone verifying the beacon.
      */
     publicKeyBytes(): Uint8Array {
-        return this.#pk.toRawBytes(true);
+        return this.#pk.toBytes(true);
     }
 
     /**
@@ -349,22 +348,7 @@ export class DerivedPublicKey {
  * input data, but this is not a common operation.
  */
 export function hashToScalar(input: Uint8Array, domainSep: string): bigint {
-    const params = {
-        p: bls12_381.params.r,
-        m: 1,
-        DST: domainSep,
-    };
-
-    const options = Object.assign(
-        {},
-        // @ts-expect-error (https://github.com/paulmillr/noble-curves/issues/179)
-        bls12_381.G2.CURVE.htfDefaults,
-        params,
-    ) as Opts;
-
-    const scalars = hash_to_field(input, 1, options);
-
-    return scalars[0][0];
+    return bls12_381.G2.hashToScalar(input, { DST: domainSep });
 }
 
 /**
@@ -425,7 +409,7 @@ export function augmentedHashToG1(
     const domainSep = "BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_AUG_";
     const pkbytes = pk.publicKeyBytes();
     const input = new Uint8Array([...pkbytes, ...message]);
-    const pt = bls12_381.G1.ProjectivePoint.fromAffine(
+    const pt = bls12_381.G1.Point.fromAffine(
         bls12_381.G1.hashToCurve(input, {
             DST: domainSep,
         }).toAffine(),
@@ -465,20 +449,14 @@ export function verifyBlsSignature(
     // The standard domain separator defined in section 4.2.2 of draft-irtf-cfrg-bls-signature
     const domainSep = "BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_AUG_";
 
-    const options = Object.assign(
-        {},
-        // @ts-expect-error (https://github.com/paulmillr/noble-curves/issues/179)
-        bls12_381.G1.CURVE.htfDefaults,
-        {
-            DST: domainSep,
-        },
-    ) as Opts;
-
-    return bls12_381.verifyShortSignature(
-        signature,
+    const hashedMessage = bls12_381.shortSignatures.hash(
         publicKeyAndMessage,
+        domainSep,
+    );
+    return bls12_381.shortSignatures.verify(
+        signature,
+        hashedMessage,
         pk.getPoint(),
-        options,
     );
 }
 
@@ -553,7 +531,7 @@ export class VetKey {
      * This deserializes the same value as returned by serialize (or signatureBytes)
      */
     static deserialize(bytes: Uint8Array): VetKey {
-        return new VetKey(bls12_381.G1.ProjectivePoint.fromHex(bytes));
+        return new VetKey(bls12_381.G1.Point.fromHex(bytes));
     }
 
     /**
@@ -573,7 +551,9 @@ export class VetKey {
      */
     constructor(pt: G1Point) {
         this.#pt = pt;
-        this.#bytes = pt.toRawBytes(true);
+
+
+        this.#bytes = pt.toBytes(true) as Uint8Array<ArrayBuffer>;
     }
 }
 
@@ -892,13 +872,11 @@ export class EncryptedVetKey {
             throw new Error("Invalid EncryptedVetKey serialization");
         }
 
-        const c1 = bls12_381.G1.ProjectivePoint.fromHex(
-            bytes.subarray(0, G1_BYTES),
-        );
-        const c2 = bls12_381.G2.ProjectivePoint.fromHex(
+        const c1 = bls12_381.G1.Point.fromHex(bytes.subarray(0, G1_BYTES));
+        const c2 = bls12_381.G2.Point.fromHex(
             bytes.subarray(G1_BYTES, G1_BYTES + G2_BYTES),
         );
-        const c3 = bls12_381.G1.ProjectivePoint.fromHex(
+        const c3 = bls12_381.G1.Point.fromHex(
             bytes.subarray(G1_BYTES + G2_BYTES),
         );
         return new EncryptedVetKey(c1, c2, c3);
@@ -914,8 +892,8 @@ export class EncryptedVetKey {
     ): VetKey {
         // Check that c1 and c2 have the same discrete logarithm, ie that e(c1, g2) == e(g1, c2)
 
-        const g1 = bls12_381.G1.ProjectivePoint.BASE;
-        const negG2 = bls12_381.G2.ProjectivePoint.BASE.negate();
+        const g1 = bls12_381.G1.Point.BASE;
+        const negG2 = bls12_381.G2.Point.BASE.negate();
         const oneGt = bls12_381.fields.Fp12.ONE;
 
         const c1c2 = bls12_381.pairingBatch([
@@ -929,9 +907,7 @@ export class EncryptedVetKey {
 
         // Compute the purported vetKey k
         const k = this.#c3.subtract(
-            this.#c1.multiply(
-                bls12_381.G1.normPrivateKeyToScalar(tsk.serialize()),
-            ),
+            this.#c1.multiply(bls12_381.G1.Point.Fn.fromBytes(tsk.serialize())),
         );
 
         // Verify that k is a valid BLS signature
@@ -1203,7 +1179,7 @@ export class IbeCiphertext {
      * Serialize the IBE ciphertext to a bytestring
      */
     serialize(): Uint8Array {
-        const c1bytes = this.#c1.toRawBytes(true);
+        const c1bytes = this.#c1.toBytes(true);
         return new Uint8Array([
             ...this.#header,
             ...c1bytes,
@@ -1221,7 +1197,7 @@ export class IbeCiphertext {
         }
 
         const header = bytes.subarray(0, IBE_HEADER_LEN);
-        const c1 = bls12_381.G2.ProjectivePoint.fromHex(
+        const c1 = bls12_381.G2.Point.fromHex(
             bytes.subarray(IBE_HEADER_LEN, IBE_HEADER_LEN + G2_BYTES),
         );
         const c2 = bytes.subarray(
@@ -1270,7 +1246,7 @@ export class IbeCiphertext {
             t,
         );
 
-        const c1 = bls12_381.G2.ProjectivePoint.BASE.multiply(t);
+        const c1 = bls12_381.G2.Point.BASE.multiply(t);
         const c2 = maskSeed(seed.getBytes(), serializeGtElem(tsig));
         const c3 = maskMsg(msg, seed.getBytes());
 
@@ -1296,8 +1272,8 @@ export class IbeCiphertext {
         const t = hashToMask(this.#header, seed, msg);
 
         const valid = isEqual(
-            bls12_381.G2.ProjectivePoint.BASE.multiply(t).toRawBytes(true),
-            this.#c1.toRawBytes(true),
+            bls12_381.G2.Point.BASE.multiply(t).toBytes(true),
+            this.#c1.toBytes(true),
         );
 
         if (valid) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,10 @@
             "version": "0.4.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@dfinity/agent": "^3.1.0",
-                "@dfinity/candid": "^3.1.0",
-                "@dfinity/principal": "^3.1.0",
+                "@icp-sdk/core": "^5.2.1",
                 "idb-keyval": "^6.2.1"
             },
             "devDependencies": {
-                "@dfinity/identity": "^3.1.0",
                 "@eslint/js": "^9.22.0",
                 "@types/node": "^24.0.4",
                 "@vitest/coverage-v8": "^3.0.5",
@@ -115,58 +112,11 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@dfinity/agent": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.1.0.tgz",
-            "integrity": "sha512-4ktWU9KoB+Y0y84i0c2up9xmek2WjwSsbh4zGUK+o3VwZyqH8Cck4Fh4eiTa5jOve/vtfSVDbUVNFXsaS3Gttw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@dfinity/cbor": "^0.2.2",
-                "@noble/curves": "^1.9.2"
-            },
-            "peerDependencies": {
-                "@dfinity/candid": "3.1.0",
-                "@dfinity/principal": "3.1.0",
-                "@noble/hashes": "^1.8.0"
-            }
-        },
-        "node_modules/@dfinity/candid": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.1.0.tgz",
-            "integrity": "sha512-YwZJROFmzPa4GCJJyGCoOYJ2pKmp9rboixGQSbLPekX0n0oU0mcEbuVKJFu6HY6CnoDoI8YKc9x+jlqh4n0u5A==",
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "@dfinity/principal": "3.1.0"
-            }
-        },
         "node_modules/@dfinity/cbor": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/@dfinity/cbor/-/cbor-0.2.2.tgz",
             "integrity": "sha512-GPJpH73kDEKbUBdUjY80lz7cq9l0vm1h/7ppejPV6O0ZTqCLrYspssYvqjRmK4aNnJ/SKXsP0rg9LYX7zpegaA==",
             "license": "Apache-2.0"
-        },
-        "node_modules/@dfinity/identity": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-3.1.0.tgz",
-            "integrity": "sha512-XI4UuzBaPh7BNaZBsQthvtrVk2S3tS24BYjKO//9+AdkNcxH3iZlzYkn6RejVaisnmztM7L0BMK3ECmGqy+OSw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "peerDependencies": {
-                "@dfinity/agent": "3.1.0",
-                "@dfinity/candid": "3.1.0",
-                "@dfinity/principal": "3.1.0",
-                "@noble/curves": "^1.9.2",
-                "@noble/hashes": "^1.8.0"
-            }
-        },
-        "node_modules/@dfinity/principal": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.1.0.tgz",
-            "integrity": "sha512-ef2JbgwQGtam0s19bH9CaR8ztpuoNx10eC6/kBjR/R8VC2eIBlaJHvD0lXDrBWGtOPZGzEy/XAugeBr3raxZ8A==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@noble/hashes": "^1.8.0"
-            }
         },
         "node_modules/@dfinity/vetkeys": {
             "resolved": "frontend/ic_vetkeys",
@@ -835,6 +785,20 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@icp-sdk/core": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@icp-sdk/core/-/core-5.3.0.tgz",
+            "integrity": "sha512-wOGPY7shB2cCuC+yXrpVd36xD5/tWZCOI9Cthe8a4SY34evoAHNmxaUN5VP28AdxVv6AVH7cfgasx4hbgk8vkg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@dfinity/cbor": "^0.2.2",
+                "@noble/curves": "^1.9.7",
+                "@noble/hashes": "^1.8.0",
+                "@scure/bip32": "^1.7.0",
+                "@scure/bip39": "^1.6.0",
+                "asn1js": "^3.0.7"
+            }
+        },
         "node_modules/@isaacs/balanced-match": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
@@ -1066,9 +1030,9 @@
             "license": "MIT"
         },
         "node_modules/@noble/curves": {
-            "version": "1.9.6",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.6.tgz",
-            "integrity": "sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA==",
+            "version": "1.9.7",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+            "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
             "license": "MIT",
             "dependencies": {
                 "@noble/hashes": "1.8.0"
@@ -1508,6 +1472,7 @@
             "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "json-schema-traverse": "^1.0.0",
@@ -1639,6 +1604,42 @@
                 "sprintf-js": "~1.0.2"
             }
         },
+        "node_modules/@scure/base": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+            "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@scure/bip32": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+            "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/curves": "~1.9.0",
+                "@noble/hashes": "~1.8.0",
+                "@scure/base": "~1.2.5"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@scure/bip39": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+            "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "~1.8.0",
+                "@scure/base": "~1.2.5"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/@shikijs/engine-oniguruma": {
             "version": "3.9.2",
             "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.9.2.tgz",
@@ -1742,6 +1743,7 @@
             "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~7.10.0"
             }
@@ -1796,6 +1798,7 @@
             "integrity": "sha512-XGwIabPallYipmcOk45DpsBSgLC64A0yvdAkrwEzwZ2viqGqRUJ8eEYoPz0CWnutgAFbNMPdsGGvzjSmcWVlEA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.27.0",
                 "@typescript-eslint/types": "8.27.0",
@@ -2251,6 +2254,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2376,9 +2380,22 @@
             "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/asn1js": {
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+            "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "pvtsutils": "^1.3.6",
+                "pvutils": "^1.1.5",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/assertion-error": {
@@ -2409,7 +2426,6 @@
             "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -2515,7 +2531,6 @@
             "integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.4.15",
                 "@types/estree": "^1.0.1",
@@ -2586,7 +2601,6 @@
             "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "mdn-data": "2.0.30",
                 "source-map-js": "^1.0.1"
@@ -2732,6 +2746,7 @@
             "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -2793,6 +2808,7 @@
             "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -3448,7 +3464,6 @@
             "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.6"
             }
@@ -3666,8 +3681,7 @@
             "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
             "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
@@ -3781,8 +3795,7 @@
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
             "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
             "dev": true,
-            "license": "CC0-1.0",
-            "peer": true
+            "license": "CC0-1.0"
         },
         "node_modules/mdurl": {
             "version": "2.0.0",
@@ -4075,7 +4088,6 @@
             "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.0",
                 "estree-walker": "^3.0.0",
@@ -4159,6 +4171,7 @@
             "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -4200,6 +4213,24 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/pvtsutils": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+            "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/pvutils": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+            "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/quansync": {
@@ -4298,6 +4329,7 @@
             "integrity": "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -4768,6 +4800,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -4838,6 +4871,12 @@
                 "typescript": ">=4.8.4"
             }
         },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
+        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4907,6 +4946,7 @@
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -4985,6 +5025,7 @@
             "integrity": "sha512-cJBdq0/u+8rgstg9t7UkBilf8ipLmeXJO30NxD5HAHOivnj10ocV8YtR/XBvd2wQpN3TmcaxNKaHX3tN7o5F5A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.6",
@@ -5125,6 +5166,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -5138,6 +5180,7 @@
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/expect": "3.2.4",


### PR DESCRIPTION
## Summary

- Replace all deprecated `@noble/curves` APIs in `utils.ts`:
  - `ProjPointType` → `WeierstrassPoint` (exported `G1Point`/`G2Point` types)
  - `@noble/hashes/sha256` → `@noble/hashes/sha2`
  - `randomPrivateKey()` → `randomSecretKey()`
  - `toRawBytes(true)` → `toBytes(true)` (7 sites)
  - `G1/G2.ProjectivePoint` → `G1/G2.Point` (all occurrences)
  - `Point.fromPrivateKey(sk)` → `Point.BASE.multiply(Point.Fn.fromBytes(sk))`
  - `G1.normPrivateKeyToScalar()` → `G1.Point.Fn.fromBytes()`
  - `verifyShortSignature()` → `shortSignatures.hash()` + `shortSignatures.verify()`
  - `G2.CURVE.htfDefaults` + manual `hash_to_field()` → `G2.hashToScalar()`
- Remove stale JSDoc `@example` blocks on `KeyManager` and `EncryptedMaps` (wrong types, non-existent methods) and the IBE usage example in `src/index.ts`
- Fix three method-level JSDoc examples using snake_case canister names instead of the camelCase TypeScript wrappers (`get_user_rights` → `getUserRights`, `remove_user` → `removeUser`)

## Test plan

- [ ] `pnpm run build` passes
- [ ] `pnpm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)