### PR TITLE
fix: align release-npm workflow with @icp-sdk sibling repos

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dfinity/ci-tools/actions/setup-pnpm@main
+      - uses: dfinity/ci-tools/actions/setup-pnpm@7bf36670eaa358cc9fec366965858e4ea84bcc66 # main
         with:
           node_version: '22'
 

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -25,11 +25,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: dfinity/ci-tools/actions/setup-pnpm@main
         with:
-          node-version: '22'
-
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+          node_version: '22'
 
       - name: Check package version matches tag
         if: ${{ github.event_name == 'push' }}
@@ -56,7 +54,6 @@ jobs:
       - name: Publish to npm
         working-directory: frontend/ic_vetkeys
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
         run: |
           if [ "${{ github.event.inputs.dry-run }}" = 'true' ]; then

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -56,10 +56,23 @@ Releases are triggered by pushing a `npm/X.Y.Z` tag to `main`. The
 
 7. **Deploy the API docs** — go to **Actions → Deploy docs to GitHub Pages → Run workflow** and enter the tag `npm/X.Y.Z`. This updates the [online docs](https://dfinity.github.io/vetkeys/) to reflect the new release.
 
+### First-time setup (one-off, before the very first release)
+
+Publishing uses GitHub OIDC — the npm CLI exchanges the GitHub Actions OIDC token for a short-lived publish token at runtime. No stored npm secret is needed. However, because `@icp-sdk/vetkeys` does not yet exist on npm, an **`@icp-sdk` npm org admin** must authorise this repo before the first publish:
+
+1. Log into [npmjs.com](https://www.npmjs.com) as an `@icp-sdk` org admin.
+2. Go to **`@icp-sdk` org settings → Publishing Access** (or the equivalent OIDC / Trusted Publishers section).
+3. Check whether publishing new packages from `dfinity/*` GitHub repos is already permitted org-wide.
+   - If yes: no action needed — the dry-run in step 5 above will confirm everything works.
+   - If no: add `dfinity/vetkeys` as a trusted publisher (repository: `dfinity/vetkeys`, workflow: `.github/workflows/release-npm.yml`, environment: `release`).
+4. Confirm by running the dry-run workflow (step 5) — a successful dry-run means auth is wired correctly and the real publish will work.
+
+> This setup is identical to what was done for `@icp-sdk/core` (`dfinity/icp-js-core`) and `@icp-sdk/bindgen` (`dfinity/icp-js-bindgen`). Once `@icp-sdk/vetkeys` exists on npm after the first release, all future releases are fully automated with no further admin steps.
+
 ### Notes
 
 - The `npm/` prefix scopes JS/TS release tags from Rust and Motoko release tags in this repo.
-- Publishing uses the org-level `NODE_AUTH_TOKEN` secret (shared across `@icp-sdk/*` packages). The `release` GitHub environment must be configured, but no per-repo secret is needed.
+- Publishing uses GitHub OIDC (`id-token: write` + `NPM_CONFIG_PROVENANCE=true`): the npm CLI exchanges the GitHub Actions OIDC token for a short-lived publish token at runtime. No stored npm secret is needed. The `release` GitHub environment must exist on this repo (already configured).
 
 ---
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -59,7 +59,7 @@ Releases are triggered by pushing a `npm/X.Y.Z` tag to `main`. The
 ### Notes
 
 - The `npm/` prefix scopes JS/TS release tags from Rust and Motoko release tags in this repo.
-- Publishing requires the `NPM_TOKEN` secret and the `release` GitHub environment to be configured.
+- Publishing uses the org-level `NODE_AUTH_TOKEN` secret (shared across `@icp-sdk/*` packages). The `release` GitHub environment must be configured, but no per-repo secret is needed.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaces the separate `actions/setup-node` + `pnpm/action-setup` steps with `dfinity/ci-tools/actions/setup-pnpm@7bf36670eaa358cc9fec366965858e4ea84bcc66 # main` — the same action (pinned to SHA, as done in `icp-js-bindgen`) used by the `@icp-sdk` sibling repos. This single step handles pnpm setup, Node setup with `registry-url` (needed to enable OIDC-based npm auth), and `pnpm install --frozen-lockfile`.
- Removes the explicit `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env var — publishing uses GitHub OIDC (`id-token: write` + `NPM_CONFIG_PROVENANCE: 'true'`): the npm CLI exchanges the GitHub Actions OIDC token for a short-lived publish token at runtime. No stored npm secret is needed. This is the same mechanism used by `@icp-sdk/core` and `@icp-sdk/bindgen`.
- Updates `RELEASING.md` to document the OIDC auth mechanism and add a first-time setup section describing the one-off steps an `@icp-sdk` npm org admin needs to take before the very first release.

## Fixes

Two bugs in the original workflow:
1. **Missing `pnpm install`** — `pnpm build` runs `tsc` + `vite`, both devDependencies not present on a fresh CI runner without a prior install step. `dfinity/ci-tools/actions/setup-pnpm` runs `pnpm install --frozen-lockfile` automatically.
2. **OIDC auth not wired** — `actions/setup-node` must be called with `registry-url` to write the `.npmrc` that enables the npm OIDC token exchange. Without it, the OIDC flow never triggers and publishing fails. `dfinity/ci-tools/actions/setup-pnpm` handles this internally.

## Verification

After merge, trigger **Actions → release-npm → Run workflow** with `dry-run: true` (the default) to confirm install, build, and auth all work end-to-end before cutting an actual release.

Note: the very first publish of `@icp-sdk/vetkeys` requires a one-off manual step — see the "First-time setup" section in `RELEASING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)