### PR TITLE
fix(encrypted_maps): harden derived key material caching

### DIFF
--- a/frontend/ic_vetkeys/CHANGELOG.md
+++ b/frontend/ic_vetkeys/CHANGELOG.md
@@ -37,7 +37,7 @@
   principal. Previously the cache key was only `[mapOwner, mapName]`, so after an
   identity switch on the same origin a different principal could receive key
   material cached by a prior one. `EncryptedMapsClient` gains a
-  `getCallerPrincipal()` method to support this; custom implementations must add it.
+  `get_caller_principal()` method to support this; custom implementations must add it.
 - **Upgrade note:** versions `0.1.0`–`0.4.0` persisted derived key material to
   IndexedDB's default `idb-keyval` store. After upgrading, those entries remain
   at rest and are neither used nor cleared by this version (the new cache uses a
@@ -46,10 +46,17 @@
 
     ```ts
     import { entries, del } from "idb-keyval";
-    // Delete only the legacy vetkeys entries (array key -> CryptoKey value)
-    // from idb-keyval's default store, leaving any other app data untouched.
+    // Delete only the legacy vetkeys entries from idb-keyval's default store,
+    // matching the exact legacy key shape `[mapOwner: string, mapName: Uint8Array]`
+    // with a CryptoKey value, leaving any other app data untouched.
     for (const [key, value] of await entries()) {
-        if (Array.isArray(key) && value instanceof CryptoKey) {
+        if (
+            Array.isArray(key) &&
+            key.length === 2 &&
+            typeof key[0] === "string" &&
+            key[1] instanceof Uint8Array &&
+            value instanceof CryptoKey
+        ) {
             await del(key);
         }
     }

--- a/frontend/ic_vetkeys/CHANGELOG.md
+++ b/frontend/ic_vetkeys/CHANGELOG.md
@@ -49,14 +49,16 @@
     ```ts
     import { entries, del } from "idb-keyval";
     // Delete only the legacy vetkeys entries from idb-keyval's default store,
-    // matching the exact legacy key shape `[mapOwner: string, mapName: Uint8Array]`
-    // with a CryptoKey value, leaving any other app data untouched.
+    // matching the legacy key shape `[mapOwner: string, mapName: bytes]` with a
+    // CryptoKey value, leaving any other app data untouched. IndexedDB does not
+    // preserve the exact JS type of binary *keys* (a Uint8Array stored as a key
+    // is read back as an ArrayBuffer), so match any binary key element.
     for (const [key, value] of await entries()) {
         if (
             Array.isArray(key) &&
             key.length === 2 &&
             typeof key[0] === "string" &&
-            key[1] instanceof Uint8Array &&
+            (key[1] instanceof ArrayBuffer || ArrayBuffer.isView(key[1])) &&
             value instanceof CryptoKey
         ) {
             await del(key);

--- a/frontend/ic_vetkeys/CHANGELOG.md
+++ b/frontend/ic_vetkeys/CHANGELOG.md
@@ -38,6 +38,22 @@
   identity switch on the same origin a different principal could receive key
   material cached by a prior one. `EncryptedMapsClient` gains a
   `getCallerPrincipal()` method to support this; custom implementations must add it.
+- **Upgrade note:** versions `0.1.0`–`0.4.0` persisted derived key material to
+  IndexedDB's default `idb-keyval` store. After upgrading, those entries remain
+  at rest and are neither used nor cleared by this version (the new cache uses a
+  dedicated store). To remove the residual decryption capability, clear the
+  legacy entries once after upgrading — e.g. via the already-bundled `idb-keyval`:
+
+    ```ts
+    import { entries, del } from "idb-keyval";
+    // Delete only the legacy vetkeys entries (array key -> CryptoKey value)
+    // from idb-keyval's default store, leaving any other app data untouched.
+    for (const [key, value] of await entries()) {
+        if (Array.isArray(key) && value instanceof CryptoKey) {
+            await del(key);
+        }
+    }
+    ```
 
 ### Changed
 

--- a/frontend/ic_vetkeys/CHANGELOG.md
+++ b/frontend/ic_vetkeys/CHANGELOG.md
@@ -19,8 +19,7 @@
 - `EncryptedMaps.clearCache()` to drop cached derived key material. Strongly
   recommended on logout or identity change to drop usable decryption capability
   — especially with `IndexedDbDerivedKeyMaterialCache`, where it persists across
-  sessions otherwise. Not required for correctness, since cached keys are scoped
-  to the caller.
+  sessions otherwise.
 
 ### Security
 
@@ -33,11 +32,14 @@
   accepting that a persisted handle can be used by any same-origin code to
   decrypt without an authenticated session. The one-time cost of the default is
   an extra key derivation per map per page load.
-- Cached derived key material is now scoped to the authenticated caller's
-  principal. Previously the cache key was only `[mapOwner, mapName]`, so after an
-  identity switch on the same origin a different principal could receive key
-  material cached by a prior one. `EncryptedMapsClient` gains a
-  `get_caller_principal()` method to support this; custom implementations must add it.
+- The derived key material cache now belongs to a single identity rather than
+  being shared in a fixed IndexedDB store across identities. Because derived key
+  material is per map (`[mapOwner, mapName]`), cross-identity isolation is a
+  property of the cache instance: use a fresh `EncryptedMaps` instance per
+  identity with the in-memory default, or give `IndexedDbDerivedKeyMaterialCache`
+  a per-identity namespace (e.g. include the caller's principal in the database
+  name). This closes the prior behaviour where, after an identity switch on the
+  same origin, key material cached by one principal could be served to another.
 - **Upgrade note:** versions `0.1.0`–`0.4.0` persisted derived key material to
   IndexedDB's default `idb-keyval` store. After upgrading, those entries remain
   at rest and are neither used nor cleared by this version (the new cache uses a

--- a/frontend/ic_vetkeys/CHANGELOG.md
+++ b/frontend/ic_vetkeys/CHANGELOG.md
@@ -12,6 +12,32 @@
 - `DerivedKeyMaterial` encryption uses a different format for encryption now.
   Decryption of old messages is supported, however older versions of this library
   will not be able to read messages encrypted by this or newer versions.
+- `EncryptedMaps` now accepts an optional `{ cache }` option to control how
+  derived key material is cached. New exports `DerivedKeyMaterialCache`,
+  `InMemoryDerivedKeyMaterialCache`, and `IndexedDbDerivedKeyMaterialCache` from
+  `@icp-sdk/vetkeys/encrypted_maps`.
+- `EncryptedMaps.clearCache()` to drop cached derived key material. Strongly
+  recommended on logout or identity change to drop usable decryption capability
+  — especially with `IndexedDbDerivedKeyMaterialCache`, where it persists across
+  sessions otherwise. Not required for correctness, since cached keys are scoped
+  to the caller.
+
+### Security
+
+- **BREAKING** `EncryptedMaps` no longer persists derived key material to
+  IndexedDB by default; it now caches in memory only
+  (`InMemoryDerivedKeyMaterialCache`), so secret-bearing key handles are
+  discarded on page reload instead of remaining usable at rest indefinitely.
+  Opt back into persistence with
+  `new EncryptedMaps(client, { cache: new IndexedDbDerivedKeyMaterialCache() })`,
+  accepting that a persisted handle can be used by any same-origin code to
+  decrypt without an authenticated session. The one-time cost of the default is
+  an extra key derivation per map per page load.
+- Cached derived key material is now scoped to the authenticated caller's
+  principal. Previously the cache key was only `[mapOwner, mapName]`, so after an
+  identity switch on the same origin a different principal could receive key
+  material cached by a prior one. `EncryptedMapsClient` gains a
+  `getCallerPrincipal()` method to support this; custom implementations must add it.
 
 ### Changed
 

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -58,7 +58,7 @@
     "module": "dist/lib/index.es.js",
     "typings": "dist/types/index.d.ts",
     "dependencies": {
-        "@icp-sdk/core": "^5.2.1",
+        "@icp-sdk/core": "^5.4.0",
         "idb-keyval": "^6.2.1"
     },
     "devDependencies": {

--- a/frontend/ic_vetkeys/src/encrypted_maps/cache.test.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/cache.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test, vi } from "vitest";
+import { Principal } from "@icp-sdk/core/principal";
+import { DerivedKeyMaterial } from "../utils/utils";
+import {
+    EncryptedMaps,
+    InMemoryDerivedKeyMaterialCache,
+    IndexedDbDerivedKeyMaterialCache,
+    type EncryptedMapsClient,
+} from "./index";
+
+/**
+ * Builds a `DerivedKeyMaterial` backed by a fresh, non-extractable HKDF key,
+ * matching what the canister flow produces — without needing a replica.
+ */
+async function newDerivedKeyMaterial(
+    seed: number,
+): Promise<DerivedKeyMaterial> {
+    const keyBytes = new Uint8Array(32).fill(seed);
+    const raw = await crypto.subtle.importKey(
+        "raw",
+        keyBytes,
+        "HKDF",
+        false, // non-extractable
+        ["deriveKey", "deriveBits"],
+    );
+    return DerivedKeyMaterial.fromCryptoKey(raw);
+}
+
+const PRINCIPAL_A = Principal.fromText("aaaaa-aa");
+const PRINCIPAL_B = Principal.fromText("rrkah-fqaaa-aaaaa-aaaaq-cai");
+
+/**
+ * Minimal client that only supports the calls the caching path needs. The
+ * remaining `EncryptedMapsClient` methods are never invoked in these tests.
+ */
+function mockClient(caller: Principal): EncryptedMapsClient {
+    return {
+        getCallerPrincipal: vi.fn(async () => caller),
+    } as unknown as EncryptedMapsClient;
+}
+
+describe("InMemoryDerivedKeyMaterialCache", () => {
+    test("round-trips a stored key handle", async () => {
+        const cache = new InMemoryDerivedKeyMaterialCache();
+        const dkm = await newDerivedKeyMaterial(1);
+        const key = dkm.getCryptoKey();
+
+        expect(await cache.get("k")).toBeUndefined();
+        await cache.set("k", key);
+        expect(await cache.get("k")).toBe(key);
+    });
+
+    test("clear() drops all entries", async () => {
+        const cache = new InMemoryDerivedKeyMaterialCache();
+        await cache.set("k", (await newDerivedKeyMaterial(1)).getCryptoKey());
+        await cache.clear();
+        expect(await cache.get("k")).toBeUndefined();
+    });
+});
+
+describe("IndexedDbDerivedKeyMaterialCache", () => {
+    test("persists a non-extractable key handle that cannot be exported", async () => {
+        // Use a unique database per test to avoid cross-test interference.
+        const cache = new IndexedDbDerivedKeyMaterialCache(
+            "ic-vetkeys-test-persist",
+            "store",
+        );
+        const key = (await newDerivedKeyMaterial(7)).getCryptoKey();
+
+        await cache.set("k", key);
+        const restored = await cache.get("k");
+        expect(restored).toBeDefined();
+        expect(restored?.extractable).toBe(false);
+        // The raw bytes must remain unrecoverable even after persistence.
+        await expect(
+            crypto.subtle.exportKey("raw", restored as CryptoKey),
+        ).rejects.toThrow();
+    });
+
+    test("clear() empties the store", async () => {
+        const cache = new IndexedDbDerivedKeyMaterialCache(
+            "ic-vetkeys-test-clear",
+            "store",
+        );
+        await cache.set("k", (await newDerivedKeyMaterial(7)).getCryptoKey());
+        expect(await cache.get("k")).toBeDefined();
+        await cache.clear();
+        expect(await cache.get("k")).toBeUndefined();
+    });
+});
+
+describe("EncryptedMaps derived key caching", () => {
+    test("fetches once, then serves subsequent calls from cache", async () => {
+        const maps = new EncryptedMaps(mockClient(PRINCIPAL_A));
+        const fetchSpy = vi
+            .spyOn(maps, "getDerivedKeyMaterial")
+            .mockImplementation(() => newDerivedKeyMaterial(1));
+        const mapName = new TextEncoder().encode("some map");
+
+        await maps.getDerivedKeyMaterialOrFetchIfNeeded(PRINCIPAL_A, mapName);
+        await maps.getDerivedKeyMaterialOrFetchIfNeeded(PRINCIPAL_A, mapName);
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("does not serve a key cached by a different caller (caller-scoped)", async () => {
+        const client = mockClient(PRINCIPAL_A);
+        const maps = new EncryptedMaps(client);
+        const fetchSpy = vi
+            .spyOn(maps, "getDerivedKeyMaterial")
+            .mockImplementation(() => newDerivedKeyMaterial(1));
+        const mapName = new TextEncoder().encode("some map");
+
+        // Caller A populates the cache.
+        await maps.getDerivedKeyMaterialOrFetchIfNeeded(PRINCIPAL_A, mapName);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+        // The authenticated identity changes to B on the same instance.
+        (
+            client.getCallerPrincipal as ReturnType<typeof vi.fn>
+        ).mockResolvedValue(PRINCIPAL_B);
+
+        // Same map owner + name, but B must NOT get A's cached key.
+        await maps.getDerivedKeyMaterialOrFetchIfNeeded(PRINCIPAL_A, mapName);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test("distinguishes maps that share a prefix in their names", async () => {
+        const maps = new EncryptedMaps(mockClient(PRINCIPAL_A));
+        const fetchSpy = vi
+            .spyOn(maps, "getDerivedKeyMaterial")
+            .mockImplementation(() => newDerivedKeyMaterial(1));
+
+        await maps.getDerivedKeyMaterialOrFetchIfNeeded(
+            PRINCIPAL_A,
+            Uint8Array.from([1]),
+        );
+        await maps.getDerivedKeyMaterialOrFetchIfNeeded(
+            PRINCIPAL_A,
+            Uint8Array.from([1, 2]),
+        );
+
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test("clearCache() forces a re-fetch", async () => {
+        const maps = new EncryptedMaps(mockClient(PRINCIPAL_A));
+        const fetchSpy = vi
+            .spyOn(maps, "getDerivedKeyMaterial")
+            .mockImplementation(() => newDerivedKeyMaterial(1));
+        const mapName = new TextEncoder().encode("some map");
+
+        await maps.getDerivedKeyMaterialOrFetchIfNeeded(PRINCIPAL_A, mapName);
+        await maps.clearCache();
+        await maps.getDerivedKeyMaterialOrFetchIfNeeded(PRINCIPAL_A, mapName);
+
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    test("a cache hit still yields working key material", async () => {
+        const shared = await newDerivedKeyMaterial(42);
+        const maps = new EncryptedMaps(mockClient(PRINCIPAL_A));
+        vi.spyOn(maps, "getDerivedKeyMaterial").mockResolvedValue(shared);
+        const mapName = new TextEncoder().encode("some map");
+
+        const plaintext = new TextEncoder().encode("hello");
+        const ciphertext = await maps.encryptFor(
+            PRINCIPAL_A,
+            mapName,
+            new TextEncoder().encode("k"),
+            plaintext,
+        );
+        // Second call resolves the key material from cache, not the fetch.
+        const decrypted = await maps.decryptFor(
+            PRINCIPAL_A,
+            mapName,
+            new TextEncoder().encode("k"),
+            ciphertext,
+        );
+
+        expect(decrypted).toEqual(plaintext);
+    });
+});

--- a/frontend/ic_vetkeys/src/encrypted_maps/cache.test.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/cache.test.ts
@@ -61,7 +61,6 @@ describe("IndexedDbDerivedKeyMaterialCache", () => {
         // Use a unique database per test to avoid cross-test interference.
         const cache = new IndexedDbDerivedKeyMaterialCache(
             "ic-vetkeys-test-persist",
-            "store",
         );
         const key = (await newDerivedKeyMaterial(7)).getCryptoKey();
 
@@ -78,7 +77,6 @@ describe("IndexedDbDerivedKeyMaterialCache", () => {
     test("clear() empties the store", async () => {
         const cache = new IndexedDbDerivedKeyMaterialCache(
             "ic-vetkeys-test-clear",
-            "store",
         );
         await cache.set("k", (await newDerivedKeyMaterial(7)).getCryptoKey());
         expect(await cache.get("k")).toBeDefined();
@@ -89,14 +87,8 @@ describe("IndexedDbDerivedKeyMaterialCache", () => {
     test("different namespaces are isolated", async () => {
         // Per-identity namespacing (e.g. `vetkeys-<principal>`) is how persisted
         // key material is kept separate between identities on the same origin.
-        const a = new IndexedDbDerivedKeyMaterialCache(
-            "ic-vetkeys-test-ns-a",
-            "store",
-        );
-        const b = new IndexedDbDerivedKeyMaterialCache(
-            "ic-vetkeys-test-ns-b",
-            "store",
-        );
+        const a = new IndexedDbDerivedKeyMaterialCache("ic-vetkeys-test-ns-a");
+        const b = new IndexedDbDerivedKeyMaterialCache("ic-vetkeys-test-ns-b");
         await a.set("k", (await newDerivedKeyMaterial(7)).getCryptoKey());
 
         expect(await a.get("k")).toBeDefined();

--- a/frontend/ic_vetkeys/src/encrypted_maps/cache.test.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/cache.test.ts
@@ -35,7 +35,7 @@ const PRINCIPAL_B = Principal.fromText("rrkah-fqaaa-aaaaa-aaaaq-cai");
  */
 function mockClient(caller: Principal): EncryptedMapsClient {
     return {
-        getCallerPrincipal: vi.fn(() => Promise.resolve(caller)),
+        get_caller_principal: vi.fn(() => Promise.resolve(caller)),
     } as unknown as EncryptedMapsClient;
 }
 
@@ -117,7 +117,7 @@ describe("EncryptedMaps derived key caching", () => {
 
         // The authenticated identity changes to B on the same instance.
         (
-            client.getCallerPrincipal as ReturnType<typeof vi.fn>
+            client.get_caller_principal as ReturnType<typeof vi.fn>
         ).mockResolvedValue(PRINCIPAL_B);
 
         // Same map owner + name, but B must NOT get A's cached key.

--- a/frontend/ic_vetkeys/src/encrypted_maps/cache.test.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/cache.test.ts
@@ -26,17 +26,15 @@ async function newDerivedKeyMaterial(
     return DerivedKeyMaterial.fromCryptoKey(raw);
 }
 
-const PRINCIPAL_A = Principal.fromText("aaaaa-aa");
-const PRINCIPAL_B = Principal.fromText("rrkah-fqaaa-aaaaa-aaaaq-cai");
+const OWNER_A = Principal.fromText("aaaaa-aa");
+const OWNER_B = Principal.fromText("rrkah-fqaaa-aaaaa-aaaaq-cai");
 
 /**
- * Minimal client that only supports the calls the caching path needs. The
- * remaining `EncryptedMapsClient` methods are never invoked in these tests.
+ * The caching path never calls the canister client (key derivation is stubbed
+ * via `getDerivedKeyMaterial`), so a bare object suffices.
  */
-function mockClient(caller: Principal): EncryptedMapsClient {
-    return {
-        get_caller_principal: vi.fn(() => Promise.resolve(caller)),
-    } as unknown as EncryptedMapsClient;
+function emptyClient(): EncryptedMapsClient {
+    return {} as unknown as EncryptedMapsClient;
 }
 
 describe("InMemoryDerivedKeyMaterialCache", () => {
@@ -87,92 +85,121 @@ describe("IndexedDbDerivedKeyMaterialCache", () => {
         await cache.clear();
         expect(await cache.get("k")).toBeUndefined();
     });
+
+    test("different namespaces are isolated", async () => {
+        // Per-identity namespacing (e.g. `vetkeys-<principal>`) is how persisted
+        // key material is kept separate between identities on the same origin.
+        const a = new IndexedDbDerivedKeyMaterialCache(
+            "ic-vetkeys-test-ns-a",
+            "store",
+        );
+        const b = new IndexedDbDerivedKeyMaterialCache(
+            "ic-vetkeys-test-ns-b",
+            "store",
+        );
+        await a.set("k", (await newDerivedKeyMaterial(7)).getCryptoKey());
+
+        expect(await a.get("k")).toBeDefined();
+        expect(await b.get("k")).toBeUndefined();
+    });
 });
 
 describe("EncryptedMaps derived key caching", () => {
     test("fetches once, then serves subsequent calls from cache", async () => {
-        const maps = new EncryptedMaps(mockClient(PRINCIPAL_A));
+        const maps = new EncryptedMaps(emptyClient());
         const fetchSpy = vi
             .spyOn(maps, "getDerivedKeyMaterial")
             .mockImplementation(() => newDerivedKeyMaterial(1));
         const mapName = new TextEncoder().encode("some map");
 
-        await maps.getDerivedKeyMaterialOrFetchIfNeeded(PRINCIPAL_A, mapName);
-        await maps.getDerivedKeyMaterialOrFetchIfNeeded(PRINCIPAL_A, mapName);
+        await maps.getDerivedKeyMaterialOrFetchIfNeeded(OWNER_A, mapName);
+        await maps.getDerivedKeyMaterialOrFetchIfNeeded(OWNER_A, mapName);
 
         expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
 
-    test("does not serve a key cached by a different caller (caller-scoped)", async () => {
-        const client = mockClient(PRINCIPAL_A);
-        const maps = new EncryptedMaps(client);
+    test("distinguishes maps by owner", async () => {
+        const maps = new EncryptedMaps(emptyClient());
         const fetchSpy = vi
             .spyOn(maps, "getDerivedKeyMaterial")
             .mockImplementation(() => newDerivedKeyMaterial(1));
         const mapName = new TextEncoder().encode("some map");
 
-        // Caller A populates the cache.
-        await maps.getDerivedKeyMaterialOrFetchIfNeeded(PRINCIPAL_A, mapName);
-        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        await maps.getDerivedKeyMaterialOrFetchIfNeeded(OWNER_A, mapName);
+        await maps.getDerivedKeyMaterialOrFetchIfNeeded(OWNER_B, mapName);
 
-        // The authenticated identity changes to B on the same instance.
-        (
-            client.get_caller_principal as ReturnType<typeof vi.fn>
-        ).mockResolvedValue(PRINCIPAL_B);
-
-        // Same map owner + name, but B must NOT get A's cached key.
-        await maps.getDerivedKeyMaterialOrFetchIfNeeded(PRINCIPAL_A, mapName);
         expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
 
     test("distinguishes maps that share a prefix in their names", async () => {
-        const maps = new EncryptedMaps(mockClient(PRINCIPAL_A));
+        const maps = new EncryptedMaps(emptyClient());
         const fetchSpy = vi
             .spyOn(maps, "getDerivedKeyMaterial")
             .mockImplementation(() => newDerivedKeyMaterial(1));
 
         await maps.getDerivedKeyMaterialOrFetchIfNeeded(
-            PRINCIPAL_A,
+            OWNER_A,
             Uint8Array.from([1]),
         );
         await maps.getDerivedKeyMaterialOrFetchIfNeeded(
-            PRINCIPAL_A,
+            OWNER_A,
             Uint8Array.from([1, 2]),
         );
 
         expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
 
+    test("separate instances do not share an in-memory cache", async () => {
+        // Distinct identities are expected to use distinct EncryptedMaps
+        // instances; their in-memory caches must be independent so one
+        // identity's key material is never served to another.
+        const first = new EncryptedMaps(emptyClient());
+        const second = new EncryptedMaps(emptyClient());
+        const firstSpy = vi
+            .spyOn(first, "getDerivedKeyMaterial")
+            .mockImplementation(() => newDerivedKeyMaterial(1));
+        const secondSpy = vi
+            .spyOn(second, "getDerivedKeyMaterial")
+            .mockImplementation(() => newDerivedKeyMaterial(2));
+        const mapName = new TextEncoder().encode("some map");
+
+        await first.getDerivedKeyMaterialOrFetchIfNeeded(OWNER_A, mapName);
+        await second.getDerivedKeyMaterialOrFetchIfNeeded(OWNER_A, mapName);
+
+        expect(firstSpy).toHaveBeenCalledTimes(1);
+        expect(secondSpy).toHaveBeenCalledTimes(1);
+    });
+
     test("clearCache() forces a re-fetch", async () => {
-        const maps = new EncryptedMaps(mockClient(PRINCIPAL_A));
+        const maps = new EncryptedMaps(emptyClient());
         const fetchSpy = vi
             .spyOn(maps, "getDerivedKeyMaterial")
             .mockImplementation(() => newDerivedKeyMaterial(1));
         const mapName = new TextEncoder().encode("some map");
 
-        await maps.getDerivedKeyMaterialOrFetchIfNeeded(PRINCIPAL_A, mapName);
+        await maps.getDerivedKeyMaterialOrFetchIfNeeded(OWNER_A, mapName);
         await maps.clearCache();
-        await maps.getDerivedKeyMaterialOrFetchIfNeeded(PRINCIPAL_A, mapName);
+        await maps.getDerivedKeyMaterialOrFetchIfNeeded(OWNER_A, mapName);
 
         expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
 
     test("a cache hit still yields working key material", async () => {
         const shared = await newDerivedKeyMaterial(42);
-        const maps = new EncryptedMaps(mockClient(PRINCIPAL_A));
+        const maps = new EncryptedMaps(emptyClient());
         vi.spyOn(maps, "getDerivedKeyMaterial").mockResolvedValue(shared);
         const mapName = new TextEncoder().encode("some map");
 
         const plaintext = new TextEncoder().encode("hello");
         const ciphertext = await maps.encryptFor(
-            PRINCIPAL_A,
+            OWNER_A,
             mapName,
             new TextEncoder().encode("k"),
             plaintext,
         );
         // Second call resolves the key material from cache, not the fetch.
         const decrypted = await maps.decryptFor(
-            PRINCIPAL_A,
+            OWNER_A,
             mapName,
             new TextEncoder().encode("k"),
             ciphertext,

--- a/frontend/ic_vetkeys/src/encrypted_maps/cache.test.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/cache.test.ts
@@ -35,7 +35,7 @@ const PRINCIPAL_B = Principal.fromText("rrkah-fqaaa-aaaaa-aaaaq-cai");
  */
 function mockClient(caller: Principal): EncryptedMapsClient {
     return {
-        getCallerPrincipal: vi.fn(async () => caller),
+        getCallerPrincipal: vi.fn(() => Promise.resolve(caller)),
     } as unknown as EncryptedMapsClient;
 }
 
@@ -69,11 +69,11 @@ describe("IndexedDbDerivedKeyMaterialCache", () => {
 
         await cache.set("k", key);
         const restored = await cache.get("k");
-        expect(restored).toBeDefined();
-        expect(restored?.extractable).toBe(false);
+        if (!restored) throw new Error("expected a cached key handle");
+        expect(restored.extractable).toBe(false);
         // The raw bytes must remain unrecoverable even after persistence.
         await expect(
-            crypto.subtle.exportKey("raw", restored as CryptoKey),
+            crypto.subtle.exportKey("raw", restored),
         ).rejects.toThrow();
     });
 

--- a/frontend/ic_vetkeys/src/encrypted_maps/cache.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/cache.ts
@@ -94,7 +94,11 @@ export class InMemoryDerivedKeyMaterialCache implements DerivedKeyMaterialCache 
  * Because the cache key does not encode the identity, **give the store a
  * per-identity namespace** to keep one identity's persisted keys from being
  * served to another on the same origin — e.g. include the caller's principal in
- * the database name: `new IndexedDbDerivedKeyMaterialCache(`vetkeys-${principal}`)`.
+ * the database name:
+ *
+ * ```ts
+ * new IndexedDbDerivedKeyMaterialCache(`vetkeys-${principal}`);
+ * ```
  *
  * A dedicated IndexedDB store is used, so {@link clear} only removes entries
  * written by this cache and never touches other application data.

--- a/frontend/ic_vetkeys/src/encrypted_maps/cache.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/cache.ts
@@ -24,9 +24,13 @@ import {
  * to decrypt. Where that handle lives therefore matters for security — see the
  * provided implementations.
  *
- * Cache entries are keyed by an opaque string that {@link EncryptedMaps} scopes
- * to the authenticated caller, the map owner, and the map name, so a key cached
- * by one identity is never served to another.
+ * Cache entries are keyed by an opaque string derived from the map owner and
+ * map name. Derived key material is per map, not per caller, so the key does
+ * not encode the identity. Isolating one identity's cached keys from another's
+ * on the same origin is therefore a property of the cache instance: use a fresh
+ * cache per identity (the in-memory default is naturally per-instance), or give
+ * a persistent cache a per-identity namespace (see
+ * {@link IndexedDbDerivedKeyMaterialCache}).
  */
 export interface DerivedKeyMaterialCache {
     /**
@@ -87,10 +91,10 @@ export class InMemoryDerivedKeyMaterialCache implements DerivedKeyMaterialCache 
  * cross-reload persistence and accept this exposure. When using this cache, be
  * sure to call {@link EncryptedMaps.clearCache} on logout or identity change.
  *
- * Note that an unauthenticated agent resolves to the anonymous principal, so
- * key material derived while anonymous is cached under a shared key and reused
- * across anonymous sessions on the same origin — consistent with the canister's
- * anonymous-access model.
+ * Because the cache key does not encode the identity, **give the store a
+ * per-identity namespace** to keep one identity's persisted keys from being
+ * served to another on the same origin — e.g. include the caller's principal in
+ * the database name: `new IndexedDbDerivedKeyMaterialCache(`vetkeys-${principal}`)`.
  *
  * A dedicated IndexedDB store is used, so {@link clear} only removes entries
  * written by this cache and never touches other application data.

--- a/frontend/ic_vetkeys/src/encrypted_maps/cache.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/cache.ts
@@ -107,11 +107,14 @@ export class IndexedDbDerivedKeyMaterialCache implements DerivedKeyMaterialCache
     readonly #store: UseStore;
 
     /**
-     * @param dbName - IndexedDB database name. Defaults to `"ic-vetkeys"`.
-     * @param storeName - Object store name. Defaults to `"derived-key-material"`.
+     * @param dbName - IndexedDB database name. Defaults to `"ic-vetkeys"`. This
+     *   is the isolation knob: give each identity its own database name (e.g.
+     *   `` `vetkeys-${principal}` ``) so one identity's persisted keys are never
+     *   served to another. The object store name is fixed, because `idb-keyval`
+     *   supports only a single object store per database.
      */
-    constructor(dbName = "ic-vetkeys", storeName = "derived-key-material") {
-        this.#store = createStore(dbName, storeName);
+    constructor(dbName = "ic-vetkeys") {
+        this.#store = createStore(dbName, "derived-key-material");
     }
 
     async get(key: string): Promise<CryptoKey | undefined> {

--- a/frontend/ic_vetkeys/src/encrypted_maps/cache.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/cache.ts
@@ -1,0 +1,118 @@
+/**
+ * @module @icp-sdk/vetkeys/encrypted_maps
+ *
+ * @description Caching strategies for derived key material. See
+ * {@link DerivedKeyMaterialCache}.
+ */
+
+import {
+    clear as idbClear,
+    createStore,
+    get as idbGet,
+    set as idbSet,
+    type UseStore,
+} from "idb-keyval";
+
+/**
+ * Strategy for caching the per-map derived key material handles used by
+ * {@link EncryptedMaps}.
+ *
+ * Deriving key material requires a canister round-trip and threshold
+ * cryptography, so it is cached and reused. The cached value is a
+ * non-extractable {@link !CryptoKey} handle: its raw bytes can never be read
+ * back (`crypto.subtle.exportKey` throws), but the handle can still be *used*
+ * to decrypt. Where that handle lives therefore matters for security — see the
+ * provided implementations.
+ *
+ * Cache entries are keyed by an opaque string that {@link EncryptedMaps} scopes
+ * to the authenticated caller, the map owner, and the map name, so a key cached
+ * by one identity is never served to another.
+ */
+export interface DerivedKeyMaterialCache {
+    /**
+     * Returns the cached key handle for the given key, or `undefined` on a miss.
+     */
+    get(key: string): Promise<CryptoKey | undefined>;
+
+    /**
+     * Stores a key handle under the given key.
+     */
+    set(key: string, value: CryptoKey): Promise<void>;
+
+    /**
+     * Removes every cached key handle.
+     *
+     * Call this on logout or whenever the authenticated identity changes to
+     * avoid leaving usable decryption capability behind.
+     */
+    clear(): Promise<void>;
+}
+
+/**
+ * Default {@link DerivedKeyMaterialCache} that keeps key handles in memory only.
+ *
+ * Nothing is written to disk, so the cache is discarded when the page is
+ * reloaded or the tab is closed and there is no at-rest exposure. The trade-off
+ * is one extra key derivation per map per page load.
+ */
+export class InMemoryDerivedKeyMaterialCache implements DerivedKeyMaterialCache {
+    readonly #entries = new Map<string, CryptoKey>();
+
+    async get(key: string): Promise<CryptoKey | undefined> {
+        return this.#entries.get(key);
+    }
+
+    async set(key: string, value: CryptoKey): Promise<void> {
+        this.#entries.set(key, value);
+    }
+
+    async clear(): Promise<void> {
+        this.#entries.clear();
+    }
+}
+
+/**
+ * Opt-in {@link DerivedKeyMaterialCache} that persists key handles in IndexedDB.
+ *
+ * Key handles survive page reloads, avoiding repeated key derivation, but this
+ * is a deliberate security trade-off: the persisted handle is non-extractable
+ * (its raw bytes cannot be stolen), yet any same-origin code — e.g. via XSS, a
+ * malicious extension, or a shared browser profile — can read the handle and
+ * use it to decrypt the user's data without an authenticated session, for as
+ * long as it remains stored.
+ *
+ * Prefer {@link InMemoryDerivedKeyMaterialCache} (the default) unless you need
+ * cross-reload persistence and accept this exposure. When using this cache, be
+ * sure to call {@link EncryptedMaps.clearCache} on logout or identity change.
+ *
+ * Note that an unauthenticated agent resolves to the anonymous principal, so
+ * key material derived while anonymous is cached under a shared key and reused
+ * across anonymous sessions on the same origin — consistent with the canister's
+ * anonymous-access model.
+ *
+ * A dedicated IndexedDB store is used, so {@link clear} only removes entries
+ * written by this cache and never touches other application data.
+ */
+export class IndexedDbDerivedKeyMaterialCache implements DerivedKeyMaterialCache {
+    readonly #store: UseStore;
+
+    /**
+     * @param dbName - IndexedDB database name. Defaults to `"ic-vetkeys"`.
+     * @param storeName - Object store name. Defaults to `"derived-key-material"`.
+     */
+    constructor(dbName = "ic-vetkeys", storeName = "derived-key-material") {
+        this.#store = createStore(dbName, storeName);
+    }
+
+    async get(key: string): Promise<CryptoKey | undefined> {
+        return idbGet<CryptoKey>(key, this.#store);
+    }
+
+    async set(key: string, value: CryptoKey): Promise<void> {
+        await idbSet(key, value, this.#store);
+    }
+
+    async clear(): Promise<void> {
+        await idbClear(this.#store);
+    }
+}

--- a/frontend/ic_vetkeys/src/encrypted_maps/cache.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/cache.ts
@@ -19,7 +19,7 @@ import {
  *
  * Deriving key material requires a canister round-trip and threshold
  * cryptography, so it is cached and reused. The cached value is a
- * non-extractable {@link !CryptoKey} handle: its raw bytes can never be read
+ * non-extractable {@link CryptoKey} handle: its raw bytes can never be read
  * back (`crypto.subtle.exportKey` throws), but the handle can still be *used*
  * to decrypt. Where that handle lives therefore matters for security — see the
  * provided implementations.

--- a/frontend/ic_vetkeys/src/encrypted_maps/cache.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/cache.ts
@@ -58,16 +58,18 @@ export interface DerivedKeyMaterialCache {
 export class InMemoryDerivedKeyMaterialCache implements DerivedKeyMaterialCache {
     readonly #entries = new Map<string, CryptoKey>();
 
-    async get(key: string): Promise<CryptoKey | undefined> {
-        return this.#entries.get(key);
+    get(key: string): Promise<CryptoKey | undefined> {
+        return Promise.resolve(this.#entries.get(key));
     }
 
-    async set(key: string, value: CryptoKey): Promise<void> {
+    set(key: string, value: CryptoKey): Promise<void> {
         this.#entries.set(key, value);
+        return Promise.resolve();
     }
 
-    async clear(): Promise<void> {
+    clear(): Promise<void> {
         this.#entries.clear();
+        return Promise.resolve();
     }
 }
 

--- a/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps_canister.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps_canister.ts
@@ -21,7 +21,7 @@ export class DefaultEncryptedMapsClient implements EncryptedMapsClient {
         });
     }
 
-    getCallerPrincipal(): Promise<Principal> {
+    get_caller_principal(): Promise<Principal> {
         return this.#agent.getPrincipal();
     }
 

--- a/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps_canister.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps_canister.ts
@@ -11,12 +11,18 @@ import { EncryptedMapsClient } from "./index";
 
 export class DefaultEncryptedMapsClient implements EncryptedMapsClient {
     actor: ActorSubclass<_DEFAULT_ENCRYPTED_MAPS_SERVICE>;
+    #agent: HttpAgent;
 
     constructor(agent: HttpAgent, canisterId: string) {
+        this.#agent = agent;
         this.actor = Actor.createActor(idlFactory, {
             agent,
             canisterId,
         });
+    }
+
+    getCallerPrincipal(): Promise<Principal> {
+        return this.#agent.getPrincipal();
     }
 
     get_accessible_shared_map_names(): Promise<[Principal, ByteBuf][]> {

--- a/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps_canister.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/encrypted_maps_canister.ts
@@ -11,18 +11,12 @@ import { EncryptedMapsClient } from "./index";
 
 export class DefaultEncryptedMapsClient implements EncryptedMapsClient {
     actor: ActorSubclass<_DEFAULT_ENCRYPTED_MAPS_SERVICE>;
-    #agent: HttpAgent;
 
     constructor(agent: HttpAgent, canisterId: string) {
-        this.#agent = agent;
         this.actor = Actor.createActor(idlFactory, {
             agent,
             canisterId,
         });
-    }
-
-    get_caller_principal(): Promise<Principal> {
-        return this.#agent.getPrincipal();
     }
 
     get_accessible_shared_map_names(): Promise<[Principal, ByteBuf][]> {

--- a/frontend/ic_vetkeys/src/encrypted_maps/index.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/index.ts
@@ -52,10 +52,14 @@ export type {
  *   reloads with {@link IndexedDbDerivedKeyMaterialCache} is an explicit, opt-in trade-off:
  *   the persisted handle is non-extractable, but any same-origin code can use it to decrypt
  *   without an authenticated session for as long as it is stored.
- * - Cached key material is scoped to the authenticated caller, so it is never served to a
- *   different identity. Even so, calling {@link EncryptedMaps.clearCache} on logout or identity
- *   change is strongly recommended to drop the still-usable decryption capability — especially
- *   with {@link IndexedDbDerivedKeyMaterialCache}, where it otherwise persists across sessions.
+ * - The cache belongs to a single authenticated identity. Identity lifecycle is the
+ *   caller's responsibility, so to avoid serving one identity's key material to another
+ *   on the same origin:
+ *   - with the in-memory default, use a **fresh `EncryptedMaps` instance per identity**
+ *     (or call {@link EncryptedMaps.clearCache} on logout / identity change);
+ *   - with {@link IndexedDbDerivedKeyMaterialCache}, give the store a **per-identity
+ *     namespace** (e.g. include the caller's principal in the database name) so entries
+ *     are physically separated, and call {@link EncryptedMaps.clearCache} on logout.
  *
  */
 export class EncryptedMaps {
@@ -91,7 +95,7 @@ export class EncryptedMaps {
      * const encryptedMaps = new EncryptedMaps(encryptedMapsClientInstance);
      * ```
      *
-     * @example Opt into persistent caching
+     * @example Opt into persistent caching, namespaced per identity
      * ```ts
      * import {
      *     EncryptedMaps,
@@ -99,7 +103,9 @@ export class EncryptedMaps {
      * } from "@icp-sdk/vetkeys/encrypted_maps";
      *
      * const encryptedMaps = new EncryptedMaps(encryptedMapsClientInstance, {
-     *     cache: new IndexedDbDerivedKeyMaterialCache(),
+     *     // Namespace the store per identity so one identity's cached keys are
+     *     // never served to another on the same origin.
+     *     cache: new IndexedDbDerivedKeyMaterialCache(`vetkeys-${myPrincipal}`),
      * });
      * // Remember to call encryptedMaps.clearCache() on logout / identity change.
      * ```
@@ -659,10 +665,7 @@ export class EncryptedMaps {
         mapOwner: Principal,
         mapName: Uint8Array,
     ): Promise<DerivedKeyMaterial> {
-        const cacheKey = await this.#derivedKeyMaterialCacheKey(
-            mapOwner,
-            mapName,
-        );
+        const cacheKey = derivedKeyMaterialCacheKey(mapOwner, mapName);
         const cachedRawDerivedKeyMaterial =
             await this.#derivedKeyMaterialCache.get(cacheKey);
         if (cachedRawDerivedKeyMaterial) {
@@ -686,28 +689,31 @@ export class EncryptedMaps {
      * Clears all cached derived key material.
      *
      * Strongly recommended on logout or whenever the authenticated identity
-     * changes: it is not required for correctness — cached keys are already
-     * scoped to the caller, so they are never served to another identity — but
-     * clearing drops the still-usable decryption capability that otherwise
-     * lingers. This matters most with {@link IndexedDbDerivedKeyMaterialCache},
-     * where cached key handles persist across sessions until cleared.
+     * changes: the cache belongs to a single identity, so clearing it (or
+     * discarding the `EncryptedMaps` instance) prevents one identity's key
+     * material from being served to another, and drops the still-usable
+     * decryption capability that otherwise lingers. This matters most with
+     * {@link IndexedDbDerivedKeyMaterialCache}, where cached key handles persist
+     * across sessions until cleared.
      */
     async clearCache(): Promise<void> {
         await this.#derivedKeyMaterialCache.clear();
     }
+}
 
-    /**
-     * Builds the cache key for a map's derived key material, scoped to the
-     * authenticated caller so a key cached by one identity is never served to
-     * another on the same origin.
-     */
-    async #derivedKeyMaterialCacheKey(
-        mapOwner: Principal,
-        mapName: Uint8Array,
-    ): Promise<string> {
-        const caller = await this.canisterClient.get_caller_principal();
-        return `${caller.toString()}|${mapOwner.toString()}|${bytesToHex(mapName)}`;
-    }
+/**
+ * Builds the cache key for a map's derived key material.
+ *
+ * Derived key material is per map (owner + name), not per caller, so the key
+ * does not include the caller. Cross-identity isolation is instead provided by
+ * the cache itself — a per-identity {@link InMemoryDerivedKeyMaterialCache}
+ * instance, or a per-identity-namespaced {@link IndexedDbDerivedKeyMaterialCache}.
+ */
+function derivedKeyMaterialCacheKey(
+    mapOwner: Principal,
+    mapName: Uint8Array,
+): string {
+    return `${mapOwner.toString()}|${bytesToHex(mapName)}`;
 }
 
 /**
@@ -910,16 +916,6 @@ export interface EncryptedMapsClient {
      * @returns Promise resolving to the verification key bytes
      */
     get_vetkey_verification_key(): Promise<ByteBuf>;
-
-    /**
-     * Returns the principal of the authenticated caller.
-     *
-     * Used to scope cached derived key material to the current identity so that
-     * a key cached by one identity is never served to another on the same origin.
-     *
-     * @returns Promise resolving to the caller's principal
-     */
-    get_caller_principal(): Promise<Principal>;
 }
 
 /**

--- a/frontend/ic_vetkeys/src/encrypted_maps/index.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/index.ts
@@ -705,7 +705,7 @@ export class EncryptedMaps {
         mapOwner: Principal,
         mapName: Uint8Array,
     ): Promise<string> {
-        const caller = await this.canisterClient.getCallerPrincipal();
+        const caller = await this.canisterClient.get_caller_principal();
         return `${caller.toString()}|${mapOwner.toString()}|${bytesToHex(mapName)}`;
     }
 }
@@ -919,7 +919,7 @@ export interface EncryptedMapsClient {
      *
      * @returns Promise resolving to the caller's principal
      */
-    getCallerPrincipal(): Promise<Principal>;
+    get_caller_principal(): Promise<Principal>;
 }
 
 /**

--- a/frontend/ic_vetkeys/src/encrypted_maps/index.ts
+++ b/frontend/ic_vetkeys/src/encrypted_maps/index.ts
@@ -5,19 +5,27 @@
  */
 
 import { Principal } from "@icp-sdk/core/principal";
-import { get, set } from "idb-keyval";
 import {
     TransportSecretKey,
     DerivedKeyMaterial,
     EncryptedVetKey,
     DerivedPublicKey,
 } from "../utils/utils";
+import {
+    type DerivedKeyMaterialCache,
+    InMemoryDerivedKeyMaterialCache,
+} from "./cache";
 import type {
     AccessRights,
     ByteBuf,
 } from "../declarations/ic_vetkeys_manager_canister/ic_vetkeys_manager_canister.did.js";
 
 export { DefaultEncryptedMapsClient } from "./encrypted_maps_canister";
+export {
+    type DerivedKeyMaterialCache,
+    InMemoryDerivedKeyMaterialCache,
+    IndexedDbDerivedKeyMaterialCache,
+} from "./cache";
 export type {
     AccessRights,
     ByteBuf,
@@ -39,6 +47,15 @@ export type {
  *
  * - **Access Rights** should be carefully managed to prevent unauthorized access.
  * - VetKeys should be decrypted **only in trusted environments** such as user browsers to prevent leaks.
+ * - Derived key material is cached **in memory by default** ({@link InMemoryDerivedKeyMaterialCache}),
+ *   so it never touches disk and is discarded on page reload. Persisting it across
+ *   reloads with {@link IndexedDbDerivedKeyMaterialCache} is an explicit, opt-in trade-off:
+ *   the persisted handle is non-extractable, but any same-origin code can use it to decrypt
+ *   without an authenticated session for as long as it is stored.
+ * - Cached key material is scoped to the authenticated caller, so it is never served to a
+ *   different identity. Even so, calling {@link EncryptedMaps.clearCache} on logout or identity
+ *   change is strongly recommended to drop the still-usable decryption capability — especially
+ *   with {@link IndexedDbDerivedKeyMaterialCache}, where it otherwise persists across sessions.
  *
  */
 export class EncryptedMaps {
@@ -53,7 +70,19 @@ export class EncryptedMaps {
     verificationKey: Uint8Array | undefined = undefined;
 
     /**
+     * Cache backing the per-map derived key material handles.
+     */
+    readonly #derivedKeyMaterialCache: DerivedKeyMaterialCache;
+
+    /**
      * Creates a new instance of the EncryptedMaps client.
+     *
+     * @param canisterClient - The client used to talk to the EncryptedMaps canister.
+     * @param options - Optional configuration.
+     * @param options.cache - Strategy for caching derived key material. Defaults to
+     *   {@link InMemoryDerivedKeyMaterialCache} (in-memory only, never persisted).
+     *   Pass {@link IndexedDbDerivedKeyMaterialCache} to persist across page reloads —
+     *   see the security note in the class description.
      *
      * @example
      * ```ts
@@ -61,9 +90,27 @@ export class EncryptedMaps {
      *
      * const encryptedMaps = new EncryptedMaps(encryptedMapsClientInstance);
      * ```
+     *
+     * @example Opt into persistent caching
+     * ```ts
+     * import {
+     *     EncryptedMaps,
+     *     IndexedDbDerivedKeyMaterialCache,
+     * } from "@icp-sdk/vetkeys/encrypted_maps";
+     *
+     * const encryptedMaps = new EncryptedMaps(encryptedMapsClientInstance, {
+     *     cache: new IndexedDbDerivedKeyMaterialCache(),
+     * });
+     * // Remember to call encryptedMaps.clearCache() on logout / identity change.
+     * ```
      */
-    constructor(canisterClient: EncryptedMapsClient) {
+    constructor(
+        canisterClient: EncryptedMapsClient,
+        options?: { cache?: DerivedKeyMaterialCache },
+    ) {
         this.canisterClient = canisterClient;
+        this.#derivedKeyMaterialCache =
+            options?.cache ?? new InMemoryDerivedKeyMaterialCache();
     }
 
     /**
@@ -612,11 +659,12 @@ export class EncryptedMaps {
         mapOwner: Principal,
         mapName: Uint8Array,
     ): Promise<DerivedKeyMaterial> {
-        const safeMapName = new Uint8Array(mapName);
-        const cachedRawDerivedKeyMaterial: CryptoKey | undefined = await get([
-            mapOwner.toString(),
-            safeMapName,
-        ]);
+        const cacheKey = await this.#derivedKeyMaterialCacheKey(
+            mapOwner,
+            mapName,
+        );
+        const cachedRawDerivedKeyMaterial =
+            await this.#derivedKeyMaterialCache.get(cacheKey);
         if (cachedRawDerivedKeyMaterial) {
             return await DerivedKeyMaterial.fromCryptoKey(
                 cachedRawDerivedKeyMaterial,
@@ -627,12 +675,50 @@ export class EncryptedMaps {
             mapOwner,
             mapName,
         );
-        await set(
-            [mapOwner.toString(), safeMapName],
+        await this.#derivedKeyMaterialCache.set(
+            cacheKey,
             derivedKeyMaterial.getCryptoKey(),
         );
         return derivedKeyMaterial;
     }
+
+    /**
+     * Clears all cached derived key material.
+     *
+     * Strongly recommended on logout or whenever the authenticated identity
+     * changes: it is not required for correctness — cached keys are already
+     * scoped to the caller, so they are never served to another identity — but
+     * clearing drops the still-usable decryption capability that otherwise
+     * lingers. This matters most with {@link IndexedDbDerivedKeyMaterialCache},
+     * where cached key handles persist across sessions until cleared.
+     */
+    async clearCache(): Promise<void> {
+        await this.#derivedKeyMaterialCache.clear();
+    }
+
+    /**
+     * Builds the cache key for a map's derived key material, scoped to the
+     * authenticated caller so a key cached by one identity is never served to
+     * another on the same origin.
+     */
+    async #derivedKeyMaterialCacheKey(
+        mapOwner: Principal,
+        mapName: Uint8Array,
+    ): Promise<string> {
+        const caller = await this.canisterClient.getCallerPrincipal();
+        return `${caller.toString()}|${mapOwner.toString()}|${bytesToHex(mapName)}`;
+    }
+}
+
+/**
+ * @internal helper to perform hex encoding
+ */
+function bytesToHex(bytes: Uint8Array): string {
+    let hex = "";
+    for (const byte of bytes) {
+        hex += byte.toString(16).padStart(2, "0");
+    }
+    return hex;
 }
 
 /**
@@ -824,6 +910,16 @@ export interface EncryptedMapsClient {
      * @returns Promise resolving to the verification key bytes
      */
     get_vetkey_verification_key(): Promise<ByteBuf>;
+
+    /**
+     * Returns the principal of the authenticated caller.
+     *
+     * Used to scope cached derived key material to the current identity so that
+     * a key cached by one identity is never served to another on the same origin.
+     *
+     * @returns Promise resolving to the caller's principal
+     */
+    getCallerPrincipal(): Promise<Principal>;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
   frontend/ic_vetkeys:
     dependencies:
       '@icp-sdk/core':
-        specifier: ^5.2.1
-        version: 5.3.0
+        specifier: ^5.4.0
+        version: 5.4.0
       idb-keyval:
         specifier: ^6.2.1
         version: 6.2.2
@@ -93,8 +93,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@dfinity/cbor@0.2.2':
-    resolution: {integrity: sha512-GPJpH73kDEKbUBdUjY80lz7cq9l0vm1h/7ppejPV6O0ZTqCLrYspssYvqjRmK4aNnJ/SKXsP0rg9LYX7zpegaA==}
+  '@dfinity/cbor@0.2.3':
+    resolution: {integrity: sha512-5GX+9tAf29r94Pxv8nCzrv2/t+AkOfem/c/G61+FA2Wadq7THvc5cvr/AVLH0LpukVfNSWRRHvl1fkCdiB9MMQ==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -313,8 +313,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@icp-sdk/core@5.3.0':
-    resolution: {integrity: sha512-wOGPY7shB2cCuC+yXrpVd36xD5/tWZCOI9Cthe8a4SY34evoAHNmxaUN5VP28AdxVv6AVH7cfgasx4hbgk8vkg==}
+  '@icp-sdk/core@5.4.0':
+    resolution: {integrity: sha512-yedhCkHIhCxI65W8id99Mi8fUgSyqKSTbD57AphquNcFV2/3Rjykng0/6H08mHswKydDcv6Y0+e8aPdrznewCw==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -409,79 +409,66 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -1686,7 +1673,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@dfinity/cbor@0.2.2': {}
+  '@dfinity/cbor@0.2.3': {}
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -1836,9 +1823,9 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@icp-sdk/core@5.3.0':
+  '@icp-sdk/core@5.4.0':
     dependencies:
-      '@dfinity/cbor': 0.2.2
+      '@dfinity/cbor': 0.2.3
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0


### PR DESCRIPTION
## Context

A Zeropath security review flagged that the EncryptedMaps frontend SDK persisted per-map derived key material (a non-extractable WebCrypto `CryptoKey`) in IndexedDB indefinitely, in a fixed store keyed only by `[mapOwner, mapName]`.

### Security assessment

The finding is **valid, with nuance**:

- The cached `CryptoKey` is **non-extractable**, so an attacker **cannot exfiltrate the raw key bytes** (`crypto.subtle.exportKey` throws). Storing a non-extractable key in IndexedDB is itself the WebCrypto-recommended pattern.
- **But the risk is real**: any same-origin code (XSS, malicious extension, shared browser profile) can *use the persisted handle in place* to decrypt and exfiltrate **plaintext**, with no authenticated session. The exposure is **data compromise**, not key theft.
- Two distinct problems:
  1. **At-rest persistence with no expiry / no clear on logout** — persisted indefinitely, extending the window for later/offline compromise. *(This is the core finding.)*
  2. **A fixed, cross-identity store** — because entries were keyed only by `[mapOwner, mapName]` in one shared store, after an identity switch on the same origin a different principal could be served key material cached by a prior one.

## Approach

Key material is cached, but **identity lifecycle stays the consumer's responsibility** — the library does not introspect the agent's identity. (An earlier revision routed the caller principal through the client interface to auto-scope the key; that was reverted because it broke the canister-mirror interface and introduced a TOCTOU race between the principal read for the key and the identity used for the fetch.)

## Changes

- **In-memory caching by default** (`InMemoryDerivedKeyMaterialCache`) — never touches disk, discarded on reload. Persistence to IndexedDB (`IndexedDbDerivedKeyMaterialCache`) is now an **explicit opt-in** via the constructor.
- **Cross-identity isolation is a property of the cache**, owned by the consumer who knows the identity:
  - in-memory default → use a fresh `EncryptedMaps` instance per identity (or `clearCache()` on switch);
  - IndexedDB → give the store a **per-identity namespace** (e.g. include the principal in the DB name).
- **`EncryptedMaps.clearCache()`** — strongly recommended on logout / identity change to drop the still-usable decryption capability.
- Configurable caching strategy via `new EncryptedMaps(client, { cache })`. The `EncryptedMapsClient` interface is **unchanged** (still a pure canister mirror).
- Bump `@icp-sdk/core` to `^5.4.0`.

## ⚠️ Breaking change

`EncryptedMaps` no longer persists key material by default (one extra key derivation per map per page load unless opting into IndexedDB). No interface changes — existing custom `EncryptedMapsClient` implementations keep working.

## Upgrading from ≤0.4.0

Versions `0.1.0`–`0.4.0` persisted derived key material to idb-keyval's **default** store. The new cache uses a **dedicated** store, so legacy entries are neither used nor cleared by this version. The CHANGELOG includes a surgical one-time cleanup snippet that deletes only legacy-shaped entries (`[string, Uint8Array] -> CryptoKey`) from the default store, leaving other app data untouched.

## Tests

- 11 tests in `cache.test.ts`: in-memory & IndexedDB round-trip, non-extractable key survives persistence (`exportKey` still rejects), cache hit/miss, **owner distinction**, **prefix-collision safety**, **separate-instance isolation**, **IndexedDB namespace isolation**, and `clearCache()` re-fetch.
- Full suite green incl. canister integration: **45/45** on `@icp-sdk/core` 5.4.0, on local + CI (Linux & macOS). `tsc`, `vite build`, `lint`, and `prettier-check` clean.

## Reviewer notes (advisory, not blocking)

- **Cache-key collisions are impossible**: the key is `${mapOwner}|${hex(mapName)}` — principal text is base32 (`[a-z2-7-]`) and `bytesToHex` is `[0-9a-f]`, so the `|` delimiter can never appear inside a field; the key is injective.
- **Cross-identity isolation is a documented consumer contract** (fresh instance / per-identity namespace + `clearCache()` on logout), not enforced by identity introspection — deliberately, to keep the canister-client interface stable and avoid a TOCTOU race.

## Note for maintainers

`package.json` still reads `0.4.0` while the CHANGELOG targets `0.5.0 - Unreleased`; the breaking change above should land under `0.5.0` per the release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)