### PR TITLE
fix(ci): single-source the pnpm version at the workspace root

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -29,8 +29,6 @@ jobs:
         with:
           node-version: '22'
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          version: 10
       - name: Provision Linux
         run: bash .github/workflows/provision-linux.sh
       - name: Frontend Tests and Lint
@@ -53,8 +51,6 @@ jobs:
         with:
           node-version: '22'
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          version: 10
       - name: Provision Darwin
         run: |
           bash .github/workflows/provision-darwin.sh

--- a/frontend/ic_vetkeys/package.json
+++ b/frontend/ic_vetkeys/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@icp-sdk/vetkeys",
     "version": "0.5.0",
-    "packageManager": "pnpm@10.10.0",
     "author": "DFINITY Stiftung",
     "description": "JavaScript and TypeScript library to use Internet Computer vetKeys",
     "homepage": "https://internetcomputer.org/docs/building-apps/network-features/vetkeys/introduction",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "private": true,
+    "packageManager": "pnpm@10.10.0",
     "scripts": {
         "build": "pnpm --recursive run build"
     }


### PR DESCRIPTION
## Why

The `release-npm` workflow failed at `setup-pnpm` with **"No pnpm version is specified"** — its `setup-pnpm` reads the **root** `package.json` for a `packageManager` field, but that field only lived in `frontend/ic_vetkeys/package.json`. (This blocked the `@icp-sdk/vetkeys` 0.5.0 release; nothing was published.)

## What

Make the **workspace root the single source of truth** for the pnpm version:
- add `"packageManager": "pnpm@10.10.0"` to the root `package.json` (canonical monorepo location, next to `pnpm-workspace.yaml`);
- remove the duplicate from `frontend/ic_vetkeys/package.json` (a dev-repo field consumers of the published package don't need — and duplication invites drift);
- drop the hardcoded `version: 10` from `frontend.yml`'s `pnpm/action-setup` so it derives the version from the root `packageManager` as well.

Now every pnpm setup — the release workflow, frontend CI, and local Corepack — resolves the version from one place.

## Verified locally

`pnpm` resolves `10.10.0` from the root pin; `pnpm install`, frontend `build`, `lint`, and `prettier --check` all pass. `frontend.yml`'s change (reading root `packageManager`) is standard `pnpm/action-setup` behavior; the release path is confirmed by the dry-run after merge.

## Note

This is the fix for one of the two release blockers. The other is a repo setting: the `release` environment's tag deployment policy `*` doesn't match `npm/0.5.0` (GitHub `*` doesn't span `/`) — add `npm/*` (and `rust/*`, `mops/*`). After merging this + fixing that policy, a `release-npm` dry-run should be green, then re-tag `npm/0.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)