### PR TITLE
fix(ci): audit only production deps in the npm release gate

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -45,7 +45,13 @@ jobs:
 
       - name: Audit dependencies
         working-directory: frontend/ic_vetkeys
-        run: pnpm audit
+        # Only audit the production dependency tree — that is what consumers
+        # install (the published package ships `dist/` plus the runtime
+        # `dependencies`). devDependencies are the build/test/docs toolchain
+        # (vite, vite-plugin-dts, typedoc, vitest, eslint, …) and never reach
+        # consumers, so their advisories must not gate a release. Dev-tooling
+        # vulnerabilities are tracked separately via Dependabot / regular CI.
+        run: pnpm audit --prod
 
       - name: Pack
         working-directory: frontend/ic_vetkeys


### PR DESCRIPTION
## Problem

The `release-npm` dry-run fails at **Audit dependencies**. `pnpm audit` audits the *entire* dependency tree, and all 19 advisories come from **devDependencies** — the build/test/docs toolchain:

| Advisory | Chain (all dev) |
|---|---|
| `fast-uri` (path traversal / host confusion) | `vite-plugin-dts` → `@microsoft/api-extractor` → `@microsoft/tsdoc-config` → `ajv` → `fast-uri` |
| `linkify-it` (ReDoS) | `typedoc` → `markdown-it` → `linkify-it` |
| `brace-expansion` (DoS) | `@vitest/coverage-v8` → … → `brace-expansion` |
| `vite` (`server.fs.deny` bypass) | `vite` |
| … | `eslint`, others |

The runtime `dependencies` (`@icp-sdk/core`, `idb-keyval`) are clean, and the published package ships only `dist/`.

## Fix

Audit the **production** tree only — `pnpm audit --prod`. That is exactly what a consumer installs when they `npm install @icp-sdk/vetkeys`, and it is verified clean (`No known vulnerabilities found`, exit 0).

## Why this is the right gate, not a workaround

- The release audit exists to protect the people who install the package. They receive `dist/` + the runtime `dependencies` — never `vite`, `typedoc`, `vitest`, etc.
- The flagged packages are deep-transitive dev dependencies we cannot directly bump; gating a release on them makes releases hostage to an unrelated moving target.
- Dev-tooling advisories are still a real supply-chain concern — but they belong to Dependabot / regular CI, not the publish blocker.

## Verification

```
$ pnpm audit --prod
No known vulnerabilities found      # exit 0

$ pnpm audit                        # full tree
… 19 advisories …                   # exit 1  (dev-only)
```

This is the second and final release-CI blocker after #412 (pnpm single-source).