### PR TITLE
fix(ci): publish over OIDC with npm on Node 24

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -27,7 +27,11 @@ jobs:
 
       - uses: dfinity/ci-tools/actions/setup-pnpm@7bf36670eaa358cc9fec366965858e4ea84bcc66 # main
         with:
-          node_version: '22'
+          # Node 24 bundles npm >= 11.5.1, which is required for OIDC trusted
+          # publishing. Node 22 ships npm 10.9, which silently skips the OIDC
+          # credential exchange and fails the publish with a masked 404. This
+          # matches the sibling @icp-sdk repos that publish over OIDC.
+          node_version: '24'
 
       - name: Check package version matches tag
         if: ${{ github.event_name == 'push' }}
@@ -55,15 +59,18 @@ jobs:
 
       - name: Pack
         working-directory: frontend/ic_vetkeys
-        run: pnpm pack
+        run: npm pack
 
       - name: Publish to npm
         working-directory: frontend/ic_vetkeys
+        # Publish with `npm` (not `pnpm publish`): OIDC trusted publishing is
+        # implemented by the npm CLI, and `npm publish` is the path the sibling
+        # @icp-sdk repos use successfully. `pnpm publish` has known OIDC issues.
         env:
           NPM_CONFIG_PROVENANCE: 'true'
         run: |
           if [ "${{ github.event.inputs.dry-run }}" = 'true' ]; then
-            pnpm publish --verbose --access public --no-git-checks --dry-run
+            npm publish --verbose --access public --dry-run
           else
-            pnpm publish --verbose --access public --no-git-checks
+            npm publish --verbose --access public
           fi


### PR DESCRIPTION
## Problem

Pushing the real `npm/0.5.0` tag failed at **Publish to npm**:

```
npm http fetch PUT 404 https://registry.npmjs.org/@icp-sdk%2fvetkeys
npm error 404  '@icp-sdk/vetkeys@0.5.0' is not in this registry.
```

The `@icp-sdk/vetkeys` package already exists (`0.5.0-beta.0`), so a 404 on the `PUT` is npm's **masked authorization failure** — the publish was never authenticated.

## Root cause

OIDC trusted publishing requires **npm ≥ 11.5.1** (and Node ≥ 22.14). The workflow pinned `node_version: '22'`, and Node 22 bundles **npm 10.9**, which does not implement the OIDC credential exchange. `pnpm publish` delegated the upload to that npm, which silently fell back to the placeholder `NODE_AUTH_TOKEN` (no rights) → masked 404. Provenance still got signed because that only needs `id-token: write`, which made the failure look contradictory.

The dry-run passed because `--dry-run` never opens the authenticated registry `PUT` — it only validates packaging.

## Fix — mirror the sibling `@icp-sdk` repos that publish over OIDC

`dfinity/icp-js-core` (which publishes `@icp-sdk/core`) uses **Node 24** (npm 11.x) and **`npm publish`**. This PR aligns `release-npm.yml`:

- `node_version: '22'` → `'24'` (Node 24 bundles npm ≥ 11.5.1)
- `pnpm publish` → `npm publish`, `pnpm pack` → `npm pack` (OIDC is implemented by the npm CLI; `pnpm publish` has known OIDC issues)

## Still required outside this PR

The npm **trusted publisher** for `@icp-sdk/vetkeys` must be configured on npmjs.com to match **this** repo/workflow/environment:
- Repository: `dfinity/vetkeys`
- Workflow: `release-npm.yml`
- Environment: `release`

If it's registered against the sibling's values (`release.yml` / `Release`), the OIDC exchange will still be rejected — but now with a clear error instead of a masked 404.

## Nothing was published

`npm view @icp-sdk/vetkeys versions` → `["0.5.0-beta.0"]`. `0.5.0` is still free.

Follow-up to #412 and #413.