### PR TITLE
fix(ci): publish over OIDC with npm on Node 24

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -27,7 +27,11 @@ jobs:
 
       - uses: dfinity/ci-tools/actions/setup-pnpm@7bf36670eaa358cc9fec366965858e4ea84bcc66 # main
         with:
-          node_version: '22'
+          # Node 24 bundles npm >= 11.5.1, which is required for OIDC trusted
+          # publishing. Node 22 ships npm 10.9, which silently skips the OIDC
+          # credential exchange and fails the publish with a masked 404. This
+          # matches the sibling @icp-sdk repos that publish over OIDC.
+          node_version: '24'
 
       - name: Check package version matches tag
         if: ${{ github.event_name == 'push' }}
@@ -55,15 +59,22 @@ jobs:
 
       - name: Pack
         working-directory: frontend/ic_vetkeys
-        run: pnpm pack
+        run: npm pack
 
       - name: Publish to npm
         working-directory: frontend/ic_vetkeys
+        # Publish with `npm` (not `pnpm publish`): OIDC trusted publishing is
+        # implemented by the npm CLI. `pnpm publish` (v10) only rides it by
+        # shelling out to npm, and that delegation is fragile — an unresolved
+        # `${NODE_AUTH_TOKEN}` placeholder in .npmrc gets sent as a literal
+        # bearer token, which the registry rejects as a masked 404 before OIDC
+        # can engage (this is exactly what failed the first 0.5.0 tag). The
+        # sibling @icp-sdk/core publishes over OIDC with `npm publish`; mirror it.
         env:
           NPM_CONFIG_PROVENANCE: 'true'
         run: |
           if [ "${{ github.event.inputs.dry-run }}" = 'true' ]; then
-            pnpm publish --verbose --access public --no-git-checks --dry-run
+            npm publish --verbose --access public --dry-run
           else
-            pnpm publish --verbose --access public --no-git-checks
+            npm publish --verbose --access public
           fi


### PR DESCRIPTION
## Problem

Pushing the real `npm/0.5.0` tag failed at **Publish to npm**:

```
npm http fetch PUT 404 https://registry.npmjs.org/@icp-sdk%2fvetkeys
npm error 404  '@icp-sdk/vetkeys@0.5.0' is not in this registry.
```

`@icp-sdk/vetkeys` already exists (`0.5.0-beta.0`), so a `404` on the `PUT` is npm's **masked authorization failure** — the publish was never authenticated. (The dry-run passed because `--dry-run` never opens the authenticated registry `PUT`; it only validates packaging.)

## Root cause

OIDC trusted publishing is implemented by the **npm CLI** and requires **npm ≥ 11.5.1** (Node ≥ 22.14). The workflow pinned `node_version: '22'`, and Node 22 bundles **npm 10.9**, which cannot do the OIDC credential exchange. `pnpm@10` publishes by shelling out to npm, and an unresolved `${NODE_AUTH_TOKEN}` placeholder in `.npmrc` was sent as a literal bearer token → masked 404 before OIDC could engage (see pnpm [#11526](https://github.com/pnpm/pnpm/pull/11526)). Provenance still signed because that only needs `id-token: write`, which made the failure look contradictory.

## Fix — mirror the proven sibling `dfinity/icp-js-core`

`icp-js-core` publishes `@icp-sdk/core` over **tokenless OIDC** and its last 6 releases (through v6.0.0) are all green. It uses **Node 24** (`.node-version`) and **`npm publish`** with no token. This PR aligns `release-npm.yml`:

- `node_version: '22' → '24'` (Node 24 bundles npm ≥ 11.5.1)
- `pnpm publish → npm publish`, `pnpm pack → npm pack` (OIDC lives in the npm CLI; `pnpm publish`'s delegation is what 404'd us)

Verified safe: the package has **no `workspace:` protocol deps** (which `npm publish` would not rewrite), plain semver `dependencies`, and `files: ["dist"]` governs packing identically.

## Still required outside this PR (blocks the publish either way)

An npm **trusted publisher** for `@icp-sdk/vetkeys` must be registered on npmjs.com matching **this** workflow exactly (case-sensitive):

| Field | Value |
|---|---|
| Organization | `dfinity` |
| Repository | `vetkeys` |
| Workflow filename | `release-npm.yml` |
| Environment | `release` |

If it was copied from `icp-js-core` (`release.yml` / `Release`), it won't match. With npm 11 a mismatch now yields an explicit "no trusted publisher" error instead of the masked 404.

## Nothing was published

`npm view @icp-sdk/vetkeys versions` → `["0.5.0-beta.0"]`. `0.5.0` is still free.

Follow-up to #412 and #413. (Supersedes the accidentally-opened-then-closed #414.)