### PR TITLE
fix(ci): single-source the pnpm version in the docs workflow

### DIFF
--- a/.github/workflows/publish-frontend-docs.yml
+++ b/.github/workflows/publish-frontend-docs.yml
@@ -28,9 +28,10 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
+      # Do not pin the pnpm version here: it is single-sourced from the root
+      # package.json `packageManager` field. Specifying both makes
+      # pnpm/action-setup fail with ERR_PNPM_BAD_PM_VERSION.
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          version: 10
 
       - name: Build docs
         run: |


### PR DESCRIPTION
## Problem

The `Deploy docs to GitHub Pages` workflow now fails at `pnpm/action-setup`:

```
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.10.0 in the package.json with the key "packageManager"
Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```

## Cause

#412 established the root `package.json` `packageManager: pnpm@10.10.0` as the single source of truth and removed the hardcoded `version: 10` from `frontend.yml` — but `publish-frontend-docs.yml` was missed and still pinned `version: 10`. `pnpm/action-setup` refuses when both a pinned `version` and a `packageManager` field are present. It passed before #412 only because the root had no `packageManager`.

## Fix

Remove `version: 10` here too, so pnpm is derived from the root `packageManager` — matching `frontend.yml`. Verified this is the only remaining workflow with the conflict.

Follow-up to #412.