### PR TITLE
chore: release ic-vetkeys at v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "ic-vetkeys"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/backend/rs/ic_vetkeys/CHANGELOG.md
+++ b/backend/rs/ic_vetkeys/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [0.8.0] - Unreleased
+## [0.8.0] - 2026-07-28
 
 ### Added
 

--- a/backend/rs/ic_vetkeys/Cargo.toml
+++ b/backend/rs/ic_vetkeys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-vetkeys"
-version = "0.7.0"
+version = "0.8.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Prepares the **`ic-vetkeys` Rust crate 0.8.0** release.

## Changes
- `backend/rs/ic_vetkeys/Cargo.toml`: `0.7.0` → `0.8.0`
- `backend/rs/ic_vetkeys/CHANGELOG.md`: dated the `0.8.0` entry (2026-07-28)
- `Cargo.lock`: updated the `ic-vetkeys` entry to `0.8.0`

## What 0.8.0 ships
`export_encrypted_maps_canister!` — a macro that generates a complete EncryptedMaps canister (`#[init]`/`#[post_upgrade]` + every endpoint) so an adopter's canister is a few lines instead of ~200 lines of boilerplate.

## Release process (after merge)
Per `RELEASING.md` (Rust section, unchanged/accurate):
1. **Dry-run:** Actions → *Publish ic-vetkeys to crates.io* → Run workflow, `crate-version = 0.8.0`, `dry-run` enabled.
2. **Publish:** same workflow, `dry-run` disabled. It verifies `Cargo.toml` matches `0.8.0`, builds+tests, and publishes to crates.io over OIDC (crates.io trusted publisher, already configured — 0.7.0 shipped this way).
3. **Marker tag:** `git tag rust/0.8.0 && git push origin rust/0.8.0`.

No tag policy / `release` environment involved — `publish.yml` is a manual `workflow_dispatch` with no `environment:` block.

crates.io currently at 0.7.0; 0.8.0 is free.