### PR TITLE
fix(docs): update frontend-library links (@icp-sdk/vetkeys); release ic-vetkeys 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "ic-vetkeys"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/backend/mo/ic_vetkeys/README.md
+++ b/backend/mo/ic_vetkeys/README.md
@@ -3,10 +3,10 @@
 This package contains a set of tools designed to help canister developers integrate **vetKeys** into their Internet Computer (ICP) applications.
 
 ## [Key Manager](https://mops.one/ic-vetkeys/docs/key_manager/KeyManager)
-A canister library for derivation of encrypted vetkeys from arbitrary strings. It can be used in combination with the [frontend key manager library](https://dfinity.github.io/vetkeys/classes/_dfinity_vetkeys_key_manager.KeyManager.html).
+A canister library for derivation of encrypted vetkeys from arbitrary strings. It can be used in combination with the [frontend key manager library](https://dfinity.github.io/vetkeys/classes/_icp-sdk_vetkeys_key_manager.KeyManager.html).
 
 ## [Encrypted Maps](https://mops.one/ic-vetkeys/docs/encrypted_maps/EncryptedMaps)
-An efficient canister library facilitating access control and encrypted storage for a collection of maps contatining key-value pairs. It can be used in combination with the [frontend encrypted maps library](https://dfinity.github.io/vetkeys/classes/_dfinity_vetkeys_encrypted_maps.EncryptedMaps.html).
+An efficient canister library facilitating access control and encrypted storage for a collection of maps contatining key-value pairs. It can be used in combination with the [frontend encrypted maps library](https://dfinity.github.io/vetkeys/classes/_icp-sdk_vetkeys_encrypted_maps.EncryptedMaps.html).
 
 ## Cross-language library
 If Rust better suits your needs, take a look at the [Rust equivalent of this library](https://docs.rs/ic_vetkeys).

--- a/backend/rs/ic_vetkeys/CHANGELOG.md
+++ b/backend/rs/ic_vetkeys/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [0.8.1] - 2026-07-28
+
+### Fixed
+
+- Corrected the frontend-library links in the crate README (the docs.rs front
+  page): they pointed at the old `@dfinity/vetkeys` TypeDoc paths, which now
+  404, and now point at the current `@icp-sdk/vetkeys` pages. Also updated a
+  `@dfinity/vetkeys` package-name mention in the `verify_bls_signature` docs.
+
 ## [0.8.0] - 2026-07-28
 
 ### Added

--- a/backend/rs/ic_vetkeys/Cargo.toml
+++ b/backend/rs/ic_vetkeys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-vetkeys"
-version = "0.8.0"
+version = "0.8.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/backend/rs/ic_vetkeys/README.md
+++ b/backend/rs/ic_vetkeys/README.md
@@ -5,10 +5,10 @@ This crate contains a set of tools designed to help canister developers integrat
 The current Minimum Supported Rust Version (MSRV) of this crate is 1.85. Any future increase in the MSRV will be accompanied by a bump in the minor version number.
 
 ## [Key Manager](https://docs.rs/ic-vetkeys/latest/ic_vetkeys/key_manager/struct.KeyManager.html)
-A canister library for derivation of encrypted vetkeys from arbitrary strings. It can be used in combination with the [frontend key manager library](https://dfinity.github.io/vetkeys/classes/_dfinity_vetkeys_key_manager.KeyManager.html).
+A canister library for derivation of encrypted vetkeys from arbitrary strings. It can be used in combination with the [frontend key manager library](https://dfinity.github.io/vetkeys/classes/_icp-sdk_vetkeys_key_manager.KeyManager.html).
 
 ## [Encrypted Maps](https://docs.rs/ic-vetkeys/latest/ic_vetkeys/encrypted_maps/struct.EncryptedMaps.html)
-An efficient canister library facilitating access control and encrypted storage for a collection of maps contatining key-value pairs. It can be used in combination with the [frontend encrypted maps library](https://dfinity.github.io/vetkeys/classes/_dfinity_vetkeys_encrypted_maps.EncryptedMaps.html).
+An efficient canister library facilitating access control and encrypted storage for a collection of maps contatining key-value pairs. It can be used in combination with the [frontend encrypted maps library](https://dfinity.github.io/vetkeys/classes/_icp-sdk_vetkeys_encrypted_maps.EncryptedMaps.html).
 
 ## [Utils](https://docs.rs/ic-vetkeys/latest/)
 For obtaining and decrypting verifiably-encrypted threshold keys via the Internet Computer vetKD system API. The API is located in the crate root.

--- a/backend/rs/ic_vetkeys/src/utils/mod.rs
+++ b/backend/rs/ic_vetkeys/src/utils/mod.rs
@@ -1496,7 +1496,7 @@ pub mod management_canister {
     /// The `context` parameter defines signer's identity.
     /// The returned signature can be verified with the public key retrieved via [`bls_public_key`] with the same `context` and `key_id`.
     /// Having the public key, message, and signature, we now can verify that the signature is valid.
-    /// For that, we can call [`verify_bls_signature`] from this crate in Rust or `verifyBlsSignature` from the `@dfinity/vetkeys` package in TypeScript/JavaScript.
+    /// For that, we can call [`verify_bls_signature`] from this crate in Rust or `verifyBlsSignature` from the `@icp-sdk/vetkeys` package in TypeScript/JavaScript.
     ///
     /// This function will use `ic0_cost_vetkd_derive_key` to calculate the precise number of cycles to attach.
     ///


### PR DESCRIPTION
## Problem

The `ic-vetkeys` crate README is rendered as the docs.rs front page, and it linked the frontend library docs via the **old `@dfinity/vetkeys`** TypeDoc paths:

- `…/classes/_dfinity_vetkeys_key_manager.KeyManager.html` → **404**
- `…/classes/_dfinity_vetkeys_encrypted_maps.EncryptedMaps.html` → **404**

The package was renamed to `@icp-sdk/vetkeys`, so TypeDoc now emits `_icp-sdk_vetkeys_*` paths. Verified the new URLs return **200**:

- https://dfinity.github.io/vetkeys/classes/_icp-sdk_vetkeys_key_manager.KeyManager.html
- https://dfinity.github.io/vetkeys/classes/_icp-sdk_vetkeys_encrypted_maps.EncryptedMaps.html

## Why a release is needed

docs.rs docs are **immutable per published version** and rebuilt from the crates.io tarball — `0.8.0`'s page can't be edited, and a docs.rs rebuild would re-read the same (stale) README. The corrected links only reach docs.rs via a **new version**, so this bumps the crate to **0.8.1** (patch, docs-only).

## Changes

- `backend/rs/ic_vetkeys/README.md`: both frontend links → `_icp-sdk_vetkeys_*`
- `backend/rs/ic_vetkeys/src/utils/mod.rs`: `@dfinity/vetkeys` → `@icp-sdk/vetkeys` in the `verify_bls_signature` doc
- `backend/rs/ic_vetkeys/Cargo.toml`: `0.8.0` → `0.8.1`; `CHANGELOG.md`: `0.8.1` entry; `Cargo.lock` updated
- `backend/mo/ic_vetkeys/README.md`: same two links fixed — corrected in-repo so they're right when **`ic-vetkeys` 0.6.0** ships to mops.one (no separate release)

## Release after merge

Rust: Actions → *Publish ic-vetkeys to crates.io* → `crate-version = 0.8.1` (dry-run first), then push `rust/0.8.1`. docs.rs will rebuild and `docs.rs/ic-vetkeys/latest/` will show the fixed links (0.8.0's page stays as-is — harmless, superseded).