### PR TITLE
docs: refresh main README (links, examples, terminology)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In slightly more detail, vetKeys enables use cases such as:
 - **Threshold BLS Signatures**, enabling secure, decentralized signing of messages.
 - **Identity Based Encryption (IBE)**, enabling secure communication between users without exchanging public keys.
 - **Verifiable Random Beacons**, providing a secure source of verifiable randomness for decentralized applications.
-- **Application defined vetKeys**, defining the constraints for obtaining derived keys/BLS signatures/verifiable randomness.
+- **Application-defined access control**, the application defines who may obtain which derived keys, BLS signatures, or verifiable randomness.
 
 The management canister API for vetKeys exposes two endpoints, one for retrieving a public key and another one for deriving encrypted keys.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a set of tools designed to help canister developers as well as frontend developers integrate **vetKeys** into their Internet Computer (ICP) applications.
 
-**vetKeys** – Verifiable Encrypted Threshold Keys – on the Internet Computer addresses the fundamental challenge of storing secrets on-chain by allowing cryptographic key derivation without exposing private keys to anyone but the user. By leveraging **threshold cryptography**, vetKeys make it possible to generate, transport, and use encrypted keys securely, unlocking **privacy-preserving smart contracts** and **externally verifiable randomness**.
+**vetKeys** – Verifiable Encrypted Threshold Keys – on the Internet Computer addresses the fundamental challenge of storing secrets on the network by allowing cryptographic key derivation without exposing private keys to anyone but the user. By leveraging **threshold cryptography**, vetKeys make it possible to generate, transport, and use encrypted keys securely, unlocking **privacy-preserving applications** and **externally verifiable randomness**.
 
 In slightly more detail, vetKeys enables use cases such as:
 
@@ -10,7 +10,7 @@ In slightly more detail, vetKeys enables use cases such as:
 - **Threshold BLS Signatures**, enabling secure, decentralized signing of messages.
 - **Identity Based Encryption (IBE)**, enabling secure communication between users without exchanging public keys.
 - **Verifiable Random Beacons**, providing a secure source of verifiable randomness for decentralized applications.
-- **Smart contract defined vetKeys**, defining the constraints for obtaining derived keys/BLS signatures/verifiable randomness.
+- **Application defined vetKeys**, defining the constraints for obtaining derived keys/BLS signatures/verifiable randomness.
 
 The management canister API for vetKeys exposes two endpoints, one for retrieving a public key and another one for deriving encrypted keys.
 
@@ -19,7 +19,7 @@ vetkd_public_key : (vetkd_public_key_args) -> (vetkd_public_key_result);
 vetkd_derive_key : (vetkd_derive_key_args) -> (vetkd_derive_key_result);
 ```
 
-For more documentation on vetKeys and the management canister API, see the [vetKeys documentation](https://internetcomputer.org/docs/building-apps/network-features/vetkeys/introduction).
+For more documentation on vetKeys and the management canister API, see the [vetKeys documentation](https://docs.internetcomputer.org/concepts/vetkeys).
 
 Please share your feedback on the [developer forum](https://forum.dfinity.org/t/threshold-key-derivation-privacy-on-the-ic/16560/179).
 
@@ -33,22 +33,21 @@ Tools to help canister developers integrate vetKeys into their Internet Computer
 - **EncryptedMaps** ([Motoko](https://mops.one/ic-vetkeys/docs/encrypted_maps/EncryptedMaps), [Rust](https://docs.rs/ic-vetkeys/latest/ic_vetkeys/encrypted_maps/struct.EncryptedMaps.html)) – a library for encrypting using vetkeys, and securely storing and sharing encrypted key-value pairs.
 - **Utils** ([Rust](https://docs.rs/ic-vetkeys/latest/)) – Utility functions for working with vetKeys.
 
-### **2. [vetKeys Frontend Library](./frontend/ic_vetkeys)** - Supports frontend developers
+### **2. vetKeys Frontend Library** ([npm](https://www.npmjs.com/package/@icp-sdk/vetkeys)) - Supports frontend developers
 
 Tools for frontend developers to interact with VetKD enabled canisters.
 
-- **[KeyManager](https://dfinity.github.io/vetkeys/classes/_dfinity_vetkeys_key_manager.KeyManager.html)** – Facilitates interaction with a KeyManager-enabled canister.
-- **[EncryptedMaps](https://dfinity.github.io/vetkeys/classes/_dfinity_vetkeys_encrypted_maps.EncryptedMaps.html)** – Facilitates interaction with a EncryptedMaps-enabled canister.
-- **[Utils](https://dfinity.github.io/vetkeys/modules/_dfinity_vetkeys.html)** – Utility functions for working with vetKeys.
+- **[KeyManager](https://dfinity.github.io/vetkeys/classes/_icp-sdk_vetkeys_key_manager.KeyManager.html)** – Facilitates interaction with a KeyManager-enabled canister.
+- **[EncryptedMaps](https://dfinity.github.io/vetkeys/classes/_icp-sdk_vetkeys_encrypted_maps.EncryptedMaps.html)** – Facilitates interaction with a EncryptedMaps-enabled canister.
+- **[Utils](https://dfinity.github.io/vetkeys/modules/_icp-sdk_vetkeys.html)** – Utility functions for working with vetKeys.
 
 ### **3. vetKeys Example Applications**
 
-Example applications are available in the [dfinity/examples](https://github.com/dfinity/examples/tree/master/rust/vetkeys) repository:
+Example applications are available in the [dfinity/examples](https://github.com/dfinity/examples) repository, most with both a Motoko and a Rust implementation:
 
-- **[Threshold BLS Signatures](https://github.com/dfinity/examples/tree/master/rust/vetkeys/basic_bls_signing)** - Demonstrates how to use vetKeys to create a threshold BLS signing service.
-- **[Identity-Based Encryption (IBE)](https://github.com/dfinity/examples/tree/master/rust/vetkeys/basic_ibe)** - Shows how to implement secure messaging using Identity Based Encryption using Internet Identity Principals as encryption IDs.
-- **[Timelock Encryption](https://github.com/dfinity/examples/tree/master/rust/vetkeys/basic_timelock_ibe)** - Implements a secret-bid auction system where bids remain encrypted until the auction is opened.
-- **[Password Manager](https://github.com/dfinity/examples/tree/master/rust/vetkeys/password_manager)** - A secure, decentralized password manager using Encrypted Maps for vault-based password storage and sharing.
-- **[Password Manager with Metadata](https://github.com/dfinity/examples/tree/master/rust/vetkeys/password_manager_with_metadata)** - Extends the basic password manager to support unencrypted metadata alongside encrypted passwords.
-- **[Encrypted Notes](https://github.com/dfinity/examples/tree/master/rust/vetkeys/encrypted_notes_dapp_vetkd)** - A secure note-taking application that uses vetKeys for encryption and enables sharing notes between users without device management.
-- **[Encrypted Chat](https://github.com/dfinity/examples/tree/master/rust/vetkeys/encrypted_chat)** - An *unfinished prototype* for an end-to-end encrypted messaging application based on vetKeys.
+- **Threshold BLS Signatures** ([Motoko](https://github.com/dfinity/examples/tree/master/motoko/vetkeys/basic_bls_signing), [Rust](https://github.com/dfinity/examples/tree/master/rust/vetkeys/basic_bls_signing)) - Demonstrates how to use vetKeys to create a threshold BLS signing service.
+- **Identity-Based Encryption (IBE)** ([Motoko](https://github.com/dfinity/examples/tree/master/motoko/vetkeys/basic_ibe), [Rust](https://github.com/dfinity/examples/tree/master/rust/vetkeys/basic_ibe)) - Shows how to implement secure messaging using Identity Based Encryption using Internet Identity Principals as encryption IDs.
+- **Timelock Encryption** ([Rust](https://github.com/dfinity/examples/tree/master/rust/vetkeys/basic_timelock_ibe)) - Implements a secret-bid auction system where bids remain encrypted until the auction is opened.
+- **Password Manager** ([Motoko](https://github.com/dfinity/examples/tree/master/motoko/vetkeys/password_manager), [Rust](https://github.com/dfinity/examples/tree/master/rust/vetkeys/password_manager)) - A secure, decentralized password manager using Encrypted Maps for vault-based password storage and sharing.
+- **Password Manager with Metadata** ([Motoko](https://github.com/dfinity/examples/tree/master/motoko/vetkeys/password_manager_with_metadata), [Rust](https://github.com/dfinity/examples/tree/master/rust/vetkeys/password_manager_with_metadata)) - Extends the basic password manager to support unencrypted metadata alongside encrypted passwords.
+- **Encrypted Notes** ([Motoko](https://github.com/dfinity/examples/tree/master/motoko/vetkeys/encrypted_notes_app_vetkd), [Rust](https://github.com/dfinity/examples/tree/master/rust/vetkeys/encrypted_notes_app_vetkd)) - A secure note-taking application that uses vetKeys for encryption and enables sharing notes between users without device management.


### PR DESCRIPTION
Refreshes the root `README.md`.

### Links
- **vetKeys docs** → `https://docs.internetcomputer.org/concepts/vetkeys` (verified 200).
- **Frontend library header** now links to **npm** (`@icp-sdk/vetkeys`), matching how the backend-library header links to mops/crates — instead of an internal path.
- **Frontend doc links** (KeyManager / EncryptedMaps / Utils) updated to the current `_icp-sdk_vetkeys_*` TypeDoc paths; the old `_dfinity_vetkeys_*` paths 404 after the package rename.

### Examples
- Each example now shows a **Motoko** and a **Rust** link behind its name (same style as the backend libraries). All 12 example URLs verified 200.
- **Encrypted Notes** path fixed: `encrypted_notes_dapp_vetkd` → `encrypted_notes_app_vetkd`.
- **Encrypted Chat** removed — it was dropped upstream.
- **Timelock Encryption** links Rust only (there is no Motoko version in `dfinity/examples`).

### Terminology
- `on-chain` → "on the network"
- "privacy-preserving smart contracts" → "privacy-preserving applications"
- "Smart contract defined vetKeys" → "Application defined vetKeys"

All README links were link-checked; remaining non-200s (crates.io, npm, forum) are anti-bot `curl` 403s for pages that exist.