### PR TITLE
feat(rust): custom_value_endpoints form for export_encrypted_maps_canister!

### DIFF
--- a/.github/workflows/backend-rust.yml
+++ b/.github/workflows/backend-rust.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           set -eExuo pipefail
           export CARGO_TERM_COLOR=always # ensure output has colors
-          cargo build --release --target wasm32-unknown-unknown -p ic-vetkeys-manager-canister -p ic-vetkeys-encrypted-maps-canister -p ic-vetkeys-canisters-tests
+          cargo build --release --target wasm32-unknown-unknown -p ic-vetkeys-manager-canister -p ic-vetkeys-encrypted-maps-canister -p ic-vetkeys-encrypted-maps-custom-canister -p ic-vetkeys-canisters-tests
           cargo test
           cargo test --doc
   cargo-test-backend-darwin:
@@ -46,6 +46,6 @@ jobs:
         run: |
           set -eExuo pipefail
           export CARGO_TERM_COLOR=always # ensure output has colors
-          cargo build --release --target wasm32-unknown-unknown -p ic-vetkeys-manager-canister -p ic-vetkeys-encrypted-maps-canister -p ic-vetkeys-canisters-tests
+          cargo build --release --target wasm32-unknown-unknown -p ic-vetkeys-manager-canister -p ic-vetkeys-encrypted-maps-canister -p ic-vetkeys-encrypted-maps-custom-canister -p ic-vetkeys-canisters-tests
           cargo test
           cargo test --doc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-vetkeys-encrypted-maps-custom-canister"
+version = "0.1.0"
+dependencies = [
+ "candid",
+ "ic-cdk 0.20.1",
+ "ic-cdk-management-canister",
+ "ic-dummy-getrandom-for-wasm",
+ "ic-stable-structures",
+ "ic-vetkeys",
+ "serde",
+]
+
+[[package]]
 name = "ic-vetkeys-manager-canister"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "backend/rs/ic_vetkeys",
     "backend/rs/ic_vetkeys_test_utils",
     "backend/rs/canisters/ic_vetkeys_encrypted_maps_canister",
+    "backend/rs/canisters/ic_vetkeys_encrypted_maps_custom_canister",
     "backend/rs/canisters/ic_vetkeys_manager_canister",
     "backend/rs/canisters/tests",
     "backend/rs/benchmarks",

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/README.md
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/README.md
@@ -5,3 +5,5 @@ This is useful for:
 
 1. running canister tests
 2. implementing dapps that only require encrypted maps
+
+It uses the full form of the [`export_encrypted_maps_canister!`](https://docs.rs/ic-vetkeys/latest/ic_vetkeys/macro.export_encrypted_maps_canister.html) macro. If your dapp keeps state linked to each value and needs to provide its own value endpoints, see [`ic-vetkeys-encrypted-maps-custom-canister`](../ic_vetkeys_encrypted_maps_custom_canister) and the macro's `custom_value_endpoints` form.

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_custom_canister/Cargo.toml
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_custom_canister/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ic-vetkeys-encrypted-maps-custom-canister"
+authors = ["DFINITY Stiftung"]
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Reference canister for the export_encrypted_maps_canister! custom_value_endpoints form"
+repository = "https://github.com/dfinity/vetkeys"
+rust-version = "1.85.0"
+
+[lib]
+path = "src/lib.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+candid = "0.10.2"
+ic-cdk = { workspace = true }
+ic-cdk-management-canister = { workspace = true }
+ic-dummy-getrandom-for-wasm = "0.1.0"
+ic-stable-structures = { workspace = true }
+ic-vetkeys = { workspace = true }
+serde = "1.0.217"

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_custom_canister/README.md
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_custom_canister/README.md
@@ -1,0 +1,18 @@
+# ic-vetkeys-encrypted-maps-custom-canister
+
+A reference canister for the `custom_value_endpoints` form of the
+[`export_encrypted_maps_canister!`](https://docs.rs/ic-vetkeys/latest/ic_vetkeys/macro.export_encrypted_maps_canister.html)
+macro.
+
+Unlike [`ic-vetkeys-encrypted-maps-canister`](../ic_vetkeys_encrypted_maps_canister),
+which exposes the full EncryptedMaps interface, this canister generates only the
+control-plane endpoints (vetKD keys, access control, map-name enumeration) plus
+the state, lifecycle hooks, and the `with_encrypted_maps`/`with_encrypted_maps_mut`
+accessors, and provides its own value read/write endpoints.
+
+This is the pattern for dapps that keep state linked to each encrypted value
+(e.g. a metadata row per entry) and therefore must own the value endpoints to
+keep the two stores consistent — see `password_manager_with_metadata` in
+[dfinity/examples](https://github.com/dfinity/examples). The endpoints here are
+kept minimal (a plain insert/get against the accessor) to exercise the macro
+form; they are not a full metadata implementation.

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_custom_canister/src/lib.rs
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_custom_canister/src/lib.rs
@@ -41,6 +41,15 @@ fn to_blob(bytes: ByteBuf) -> Result<Blob<32>, String> {
 // A canister-owned value write, wrapping the library's own via the accessor.
 // This is where linked side-state (metadata, counters, …) would be maintained
 // in the same call — kept minimal here.
+//
+// Parameters (matching the EncryptedMaps model):
+// - `map_owner`: the principal that owns the map; together with `map_name` it
+//   identifies the map. Maps are namespaced per owner.
+// - `map_name`: the map's name within the owner's namespace (max 32 bytes).
+// - `map_key`: the key of the entry within that map (max 32 bytes).
+// - `value`: the already client-side-encrypted value to store.
+// Returns the previous value at that key, if any. Access is checked against the
+// caller (`msg_caller`) by the library.
 #[ic_cdk::update]
 fn insert_encrypted_value_custom(
     map_owner: Principal,
@@ -59,6 +68,10 @@ fn insert_encrypted_value_custom(
 }
 
 // A canister-owned value read via the shared-reference accessor.
+//
+// `map_owner` + `map_name` identify the map, `map_key` the entry within it (see
+// `insert_encrypted_value_custom`). Returns the encrypted value at that key, if
+// any; access is checked against the caller by the library.
 #[ic_cdk::query]
 fn get_encrypted_value_custom(
     map_owner: Principal,

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_custom_canister/src/lib.rs
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_custom_canister/src/lib.rs
@@ -1,0 +1,77 @@
+// Reference canister for the `custom_value_endpoints` form of
+// `export_encrypted_maps_canister!`. It generates the control-plane endpoints
+// plus the state, lifecycle hooks, and the `with_encrypted_maps`/`_mut`
+// accessors, but NOT the value read/write endpoints — the canister exposes its
+// own. This is the pattern an app uses when it keeps state linked to each value
+// (e.g. a metadata row per entry) and must own the value endpoints to keep that
+// state consistent.
+//
+// This minimal example just re-implements a plain insert/get against the
+// accessor to exercise the surface; a full linked-metadata example lives in
+// `password_manager_with_metadata` in dfinity/examples.
+use candid::Principal;
+use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
+use ic_stable_structures::storable::Blob;
+use ic_stable_structures::DefaultMemoryImpl;
+use ic_vetkeys::types::{ByteBuf, EncryptedMapValue};
+use std::cell::RefCell;
+
+type Memory = VirtualMemory<DefaultMemoryImpl>;
+
+thread_local! {
+    static MEMORY_MANAGER: RefCell<MemoryManager<DefaultMemoryImpl>> =
+        RefCell::new(MemoryManager::init(DefaultMemoryImpl::default()));
+}
+
+fn memory(id: u8) -> Memory {
+    MEMORY_MANAGER.with(|m| m.borrow().get(MemoryId::new(id)))
+}
+
+// Control plane + state + lifecycle + accessors; no value endpoints.
+ic_vetkeys::export_encrypted_maps_canister!(
+    "encrypted_maps_custom_dapp",
+    [memory(0), memory(1), memory(2), memory(3)],
+    custom_value_endpoints,
+);
+
+fn to_blob(bytes: ByteBuf) -> Result<Blob<32>, String> {
+    Blob::try_from(bytes.as_ref()).map_err(|_| "too large input".to_string())
+}
+
+// A canister-owned value write, wrapping the library's own via the accessor.
+// This is where linked side-state (metadata, counters, …) would be maintained
+// in the same call — kept minimal here.
+#[ic_cdk::update]
+fn insert_encrypted_value_custom(
+    map_owner: Principal,
+    map_name: ByteBuf,
+    map_key: ByteBuf,
+    value: EncryptedMapValue,
+) -> Result<Option<EncryptedMapValue>, String> {
+    with_encrypted_maps_mut(|encrypted_maps| {
+        encrypted_maps.insert_encrypted_value(
+            ic_cdk::api::msg_caller(),
+            (map_owner, to_blob(map_name)?),
+            to_blob(map_key)?,
+            value,
+        )
+    })
+}
+
+// A canister-owned value read via the shared-reference accessor.
+#[ic_cdk::query]
+fn get_encrypted_value_custom(
+    map_owner: Principal,
+    map_name: ByteBuf,
+    map_key: ByteBuf,
+) -> Result<Option<EncryptedMapValue>, String> {
+    with_encrypted_maps(|encrypted_maps| {
+        encrypted_maps.get_encrypted_value(
+            ic_cdk::api::msg_caller(),
+            (map_owner, to_blob(map_name)?),
+            to_blob(map_key)?,
+        )
+    })
+}
+
+ic_cdk::export_candid!();

--- a/backend/rs/ic_vetkeys/CHANGELOG.md
+++ b/backend/rs/ic_vetkeys/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [Unreleased]
+
+### Added
+
+- `export_encrypted_maps_canister!` gained a `custom_value_endpoints` form. It
+  generates the control-plane endpoints, the stable state, the
+  `#[init]`/`#[post_upgrade]` hooks, and `with_encrypted_maps`/`_mut` accessors,
+  but omits every endpoint that reads or writes encrypted map values — for
+  canisters that keep state linked to each value (e.g. a metadata row per entry)
+  and must own the value endpoints to keep that state consistent. Reuse the
+  library's vetKD/crypto/access-control logic from your own endpoints via the
+  accessors. The full form is unchanged and its generated Candid is identical.
+
 ## [0.8.1] - 2026-07-28
 
 ### Fixed

--- a/backend/rs/ic_vetkeys/README.md
+++ b/backend/rs/ic_vetkeys/README.md
@@ -10,6 +10,20 @@ A canister library for derivation of encrypted vetkeys from arbitrary strings. I
 ## [Encrypted Maps](https://docs.rs/ic-vetkeys/latest/ic_vetkeys/encrypted_maps/struct.EncryptedMaps.html)
 An efficient canister library facilitating access control and encrypted storage for a collection of maps contatining key-value pairs. It can be used in combination with the [frontend encrypted maps library](https://dfinity.github.io/vetkeys/classes/_icp-sdk_vetkeys_encrypted_maps.EncryptedMaps.html).
 
+## Ready-made EncryptedMaps canister
+
+The [`export_encrypted_maps_canister!`](https://docs.rs/ic-vetkeys/latest/ic_vetkeys/macro.export_encrypted_maps_canister.html) macro generates a complete EncryptedMaps canister — the `#[init]`/`#[post_upgrade]`, the stable state, and every endpoint the `@icp-sdk/vetkeys` frontend expects — in a few lines instead of ~200 of hand-written boilerplate:
+
+```ignore
+ic_vetkeys::export_encrypted_maps_canister!(
+    "my_app_domain_separator",
+    [memory(0), memory(1), memory(2), memory(3)],
+);
+ic_cdk::export_candid!();
+```
+
+If your canister keeps state linked to each value (e.g. a metadata row per entry) and must own the value read/write endpoints, pass `custom_value_endpoints`: the macro then generates the control-plane endpoints, state, lifecycle hooks, and `with_encrypted_maps`/`with_encrypted_maps_mut` accessors, but omits the value endpoints so you can provide your own. See the [macro documentation](https://docs.rs/ic-vetkeys/latest/ic_vetkeys/macro.export_encrypted_maps_canister.html) for the full setup and rationale.
+
 ## [Utils](https://docs.rs/ic-vetkeys/latest/)
 For obtaining and decrypting verifiably-encrypted threshold keys via the Internet Computer vetKD system API. The API is located in the crate root.
 

--- a/backend/rs/ic_vetkeys/src/encrypted_maps/canister.rs
+++ b/backend/rs/ic_vetkeys/src/encrypted_maps/canister.rs
@@ -1,17 +1,31 @@
-//! Macro that generates a complete EncryptedMaps canister.
+//! Macro that generates an EncryptedMaps canister.
 //!
 //! [`export_encrypted_maps_canister!`] expands — in the calling crate — to the
-//! `#[init]`, the stable state, and every `#[query]`/`#[update]` endpoint, so an
-//! adopter's `lib.rs` can be a few lines instead of ~200 lines of hand-written
-//! boilerplate. Because the macro is the single source of the endpoint set, the
-//! exposed Candid interface is exactly the one the `@icp-sdk/vetkeys` frontend
-//! expects, by construction.
+//! `#[init]`/`#[post_upgrade]`, the stable state, and the `#[query]`/`#[update]`
+//! endpoints, so an adopter's `lib.rs` can be a few lines instead of ~200 lines
+//! of hand-written boilerplate. Because the macro is the single source of the
+//! endpoint set, the exposed Candid interface is exactly the one the
+//! `@icp-sdk/vetkeys` frontend expects, by construction.
+//!
+//! It has two forms:
+//!
+//! * **Full** (the common case) — every endpoint, a complete drop-in canister.
+//! * **`custom_value_endpoints`** — the same *control-plane* endpoints (vetKD
+//!   keys, access control, map-name enumeration) plus the state and lifecycle
+//!   hooks and a [`with_encrypted_maps`]/[`with_encrypted_maps_mut`] accessor,
+//!   but **none** of the endpoints that read or write encrypted map *values*.
+//!   Use this when the canister keeps extra state linked to each value (e.g. a
+//!   metadata row per entry) and must own the value read/write endpoints itself
+//!   to keep that state consistent.
 //!
 //! The generated code refers to the calling crate's dependencies, so an adopter
 //! must depend on: `ic-cdk`, `ic-cdk-management-canister`, `ic-stable-structures`,
 //! `candid`, and `ic-vetkeys`.
+//!
+//! [`with_encrypted_maps`]: #accessing-the-encryptedmaps-instance
+//! [`with_encrypted_maps_mut`]: #accessing-the-encryptedmaps-instance
 
-/// Generates a complete EncryptedMaps canister in the calling crate.
+/// Generates an EncryptedMaps canister in the calling crate.
 ///
 /// A canister may have only one
 /// [`MemoryManager`](ic_stable_structures::memory_manager::MemoryManager), so
@@ -23,15 +37,15 @@
 ///
 /// The `#[init]` takes the vetKD key name (e.g. `"test_key_1"` locally,
 /// `"key_1"` on mainnet). The macro injects the canister entry points into the
-/// invoking module — the `#[init]`/`#[post_upgrade]` and every `#[query]`/
-/// `#[update]` endpoint (plus a private thread-local and helpers) — but it does
+/// invoking module — the `#[init]`/`#[post_upgrade]` and the `#[query]`/
+/// `#[update]` endpoints (plus a private thread-local and helpers) — but it does
 /// **not** bind any common names in your scope (all library types are imported
 /// under unique aliases), so it won't clash with your own `use` imports. It
 /// does not emit the Candid interface, because `ic_cdk::export_candid!()`
 /// cannot be expanded from within another macro — call it yourself after the
 /// macro.
 ///
-/// # Example
+/// # Full canister
 ///
 /// ```ignore
 /// use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
@@ -58,8 +72,97 @@
 ///
 /// The `domain_separator` isolates the derived keys of this application from
 /// other vetKeys deployments and must stay stable for the life of the canister.
+///
+/// # Bring your own value endpoints (`custom_value_endpoints`)
+///
+/// Pass the `custom_value_endpoints` marker to generate everything **except**
+/// the endpoints that read or write encrypted map values. This is for the
+/// "wrap-and-extend" pattern: a canister that stores something *alongside* each
+/// value — for example a backend-authoritative metadata record per entry — and
+/// therefore must expose its own `*_with_metadata` read/write endpoints and keep
+/// the two stores consistent in a single call.
+///
+/// ```ignore
+/// // Generates: #[init]/#[post_upgrade], the stable EncryptedMaps state, the
+/// // control-plane endpoints, and the `with_encrypted_maps`/`_mut` accessors.
+/// // Does NOT generate any value read/write endpoints.
+/// ic_vetkeys::export_encrypted_maps_canister!(
+///     "my_app_domain_separator",
+///     [memory(0), memory(1), memory(2), memory(3)],
+///     custom_value_endpoints,
+/// );
+///
+/// thread_local! {
+///     // Adopter-owned side-state, in the same MemoryManager under another id.
+///     static METADATA: RefCell<MetadataMap> =
+///         RefCell::new(ic_stable_structures::StableBTreeMap::init(memory(4)));
+/// }
+///
+/// #[ic_cdk::update]
+/// fn insert_encrypted_value_with_metadata(
+///     map_owner: Principal, map_name: ByteBuf, map_key: ByteBuf,
+///     value: EncryptedMapValue, /* ...app fields... */
+/// ) -> Result<Option<EncryptedMapValue>, String> {
+///     // Reuse the library's crypto + access control via the accessor:
+///     let previous = with_encrypted_maps_mut(|em| em.insert_encrypted_value(
+///         ic_cdk::api::msg_caller(),
+///         (map_owner, blob(map_name)?),
+///         blob(map_key)?,
+///         value,
+///     ))?;
+///     // ...maintain the linked METADATA row in the same call...
+///     Ok(previous)
+/// }
+/// ic_cdk::export_candid!();
+/// ```
+///
+/// ## Which endpoints are omitted, and why
+///
+/// The omitted set is the **value data-plane** — the endpoints whose result or
+/// effect is an encrypted map value:
+///
+/// * writes: `insert_encrypted_value`, `remove_encrypted_value`,
+///   `remove_map_values`
+/// * reads: `get_encrypted_value`, `get_encrypted_values_for_map`,
+///   `get_all_accessible_encrypted_values`, `get_all_accessible_encrypted_maps`
+///
+/// Only the **writes** can break an adopter's invariant (they mutate the value
+/// store, so a raw write could leave your linked side-state out of sync — a
+/// correctness issue). The **reads** are omitted for API-surface hygiene: with a
+/// wrapped read like `*_with_metadata`, you almost never also want a
+/// metadata-less value view sitting next to it. Omitting the whole group is a
+/// deliberate, safe-by-construction cut: it is one decision instead of a
+/// per-endpoint exclusion list you could under-specify (leaving a value endpoint
+/// exposed), and any value endpoint added to the library in future is hidden
+/// from `custom_value_endpoints` adopters automatically.
+///
+/// If you only need to guard writes and are happy keeping the standard value
+/// reads, you currently re-implement those reads by hand; a fine-grained
+/// exclusion API can be added later if that need becomes real.
+///
+/// The generated **control-plane** endpoints are always safe to keep — none of
+/// them read or write map values (`set_user_rights`/`remove_user` touch only the
+/// access-control state, with no value cascade):
+/// `get_accessible_shared_map_names`, `get_shared_user_access_for_map`,
+/// `get_owned_non_empty_map_names`, `get_vetkey_verification_key`,
+/// `get_encrypted_vetkey`, `get_user_rights`, `set_user_rights`, `remove_user`.
+///
+/// ## Accessing the EncryptedMaps instance
+///
+/// Both forms emit two accessors so your own endpoints can reuse the library's
+/// vetKD/crypto/access-control logic without re-wiring init or memory:
+///
+/// ```ignore
+/// fn with_encrypted_maps<R>(f: impl FnOnce(&EncryptedMaps<AccessRights>) -> R) -> R;
+/// fn with_encrypted_maps_mut<R>(f: impl FnOnce(&mut EncryptedMaps<AccessRights>) -> R) -> R;
+/// ```
+///
+/// Note that `with_encrypted_maps_mut` gives you the raw value mutators
+/// (`insert_encrypted_value`, …). When you wrap them, keep your linked
+/// side-state updated in the *same* endpoint call.
 #[macro_export]
 macro_rules! export_encrypted_maps_canister {
+    // Full canister: control-plane + value endpoints.
     (
         $domain_separator:expr,
         [
@@ -68,6 +171,59 @@ macro_rules! export_encrypted_maps_canister {
             $memory_shared_keys:expr,
             $memory_encrypted_maps:expr $(,)?
         ] $(,)?
+    ) => {
+        $crate::__export_encrypted_maps_common!(
+            $domain_separator,
+            [
+                $memory_domain_separator,
+                $memory_access_control,
+                $memory_shared_keys,
+                $memory_encrypted_maps
+            ]
+        );
+        $crate::__export_encrypted_maps_control_plane_endpoints!();
+        $crate::__export_encrypted_maps_value_endpoints!();
+    };
+
+    // Control-plane only: caller provides its own value read/write endpoints.
+    (
+        $domain_separator:expr,
+        [
+            $memory_domain_separator:expr,
+            $memory_access_control:expr,
+            $memory_shared_keys:expr,
+            $memory_encrypted_maps:expr $(,)?
+        ],
+        custom_value_endpoints $(,)?
+    ) => {
+        $crate::__export_encrypted_maps_common!(
+            $domain_separator,
+            [
+                $memory_domain_separator,
+                $memory_access_control,
+                $memory_shared_keys,
+                $memory_encrypted_maps
+            ]
+        );
+        $crate::__export_encrypted_maps_control_plane_endpoints!();
+    };
+}
+
+/// State, lifecycle hooks, helpers, and accessors shared by both forms.
+///
+/// Not a public API — an implementation detail of
+/// [`export_encrypted_maps_canister!`].
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __export_encrypted_maps_common {
+    (
+        $domain_separator:expr,
+        [
+            $memory_domain_separator:expr,
+            $memory_access_control:expr,
+            $memory_shared_keys:expr,
+            $memory_encrypted_maps:expr
+        ]
     ) => {
         // Import everything under unique aliases so the expansion never binds a
         // common name (`Principal`, `ByteBuf`, …) in the caller's module — that
@@ -127,6 +283,38 @@ macro_rules! export_encrypted_maps_canister {
             });
         }
 
+        /// Run `f` with a shared reference to the initialized `EncryptedMaps`.
+        ///
+        /// For hand-written endpoints that reuse the library's vetKD / crypto /
+        /// access-control logic. Traps if called before `#[init]` (it never is —
+        /// the state is set up in `#[init]`/`#[post_upgrade]`).
+        #[allow(dead_code)]
+        fn with_encrypted_maps<__EmR>(
+            f: impl FnOnce(&__EmEncryptedMaps<__EmAccessRights>) -> __EmR,
+        ) -> __EmR {
+            ENCRYPTED_MAPS.with_borrow(|encrypted_maps| f(encrypted_maps.as_ref().unwrap()))
+        }
+
+        /// Run `f` with a mutable reference to the initialized `EncryptedMaps`.
+        ///
+        /// Gives access to the raw value mutators; when wrapping them, keep any
+        /// linked side-state updated in the same endpoint call.
+        #[allow(dead_code)]
+        fn with_encrypted_maps_mut<__EmR>(
+            f: impl FnOnce(&mut __EmEncryptedMaps<__EmAccessRights>) -> __EmR,
+        ) -> __EmR {
+            ENCRYPTED_MAPS.with_borrow_mut(|encrypted_maps| f(encrypted_maps.as_mut().unwrap()))
+        }
+    };
+}
+
+/// The control-plane endpoints (vetKD keys, access control, map-name
+/// enumeration). None of these read or write encrypted map values, so they are
+/// always safe to emit. Not a public API.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __export_encrypted_maps_control_plane_endpoints {
+    () => {
         #[::ic_cdk::query]
         fn get_accessible_shared_map_names() -> Vec<(__EmPrincipal, __EmByteBuf)> {
             ENCRYPTED_MAPS.with_borrow(|encrypted_maps| {
@@ -156,98 +344,6 @@ macro_rules! export_encrypted_maps_canister {
         }
 
         #[::ic_cdk::query]
-        fn get_encrypted_values_for_map(
-            map_owner: __EmPrincipal,
-            map_name: __EmByteBuf,
-        ) -> Result<Vec<(__EmByteBuf, __EmEncryptedMapValue)>, String> {
-            let map_name = __encrypted_maps_bytebuf_to_blob(map_name)?;
-            let map_id = (map_owner, map_name);
-            let result = ENCRYPTED_MAPS.with_borrow(|encrypted_maps| {
-                encrypted_maps
-                    .as_ref()
-                    .unwrap()
-                    .get_encrypted_values_for_map(::ic_cdk::api::msg_caller(), map_id)
-            });
-            result.map(|map_values| {
-                map_values
-                    .into_iter()
-                    .map(|(key, value)| (__EmByteBuf::from(key.as_slice().to_vec()), value))
-                    .collect()
-            })
-        }
-
-        #[::ic_cdk::query]
-        fn get_all_accessible_encrypted_values(
-        ) -> Vec<((__EmPrincipal, __EmByteBuf), Vec<(__EmByteBuf, __EmEncryptedMapValue)>)> {
-            ENCRYPTED_MAPS
-                .with_borrow(|encrypted_maps| {
-                    encrypted_maps
-                        .as_ref()
-                        .unwrap()
-                        .get_all_accessible_encrypted_values(::ic_cdk::api::msg_caller())
-                })
-                .into_iter()
-                .map(|((owner, map_name), encrypted_values)| {
-                    (
-                        (owner, __EmByteBuf::from(map_name.as_ref().to_vec())),
-                        encrypted_values
-                            .into_iter()
-                            .map(|(key, value)| (__EmByteBuf::from(key.as_ref().to_vec()), value))
-                            .collect(),
-                    )
-                })
-                .collect()
-        }
-
-        #[::ic_cdk::query]
-        fn get_all_accessible_encrypted_maps() -> Vec<__EmEncryptedMapData<__EmAccessRights>> {
-            ENCRYPTED_MAPS.with_borrow(|encrypted_maps| {
-                encrypted_maps
-                    .as_ref()
-                    .unwrap()
-                    .get_all_accessible_encrypted_maps(::ic_cdk::api::msg_caller())
-            })
-        }
-
-        #[::ic_cdk::query]
-        fn get_encrypted_value(
-            map_owner: __EmPrincipal,
-            map_name: __EmByteBuf,
-            map_key: __EmByteBuf,
-        ) -> Result<Option<__EmEncryptedMapValue>, String> {
-            let map_name = __encrypted_maps_bytebuf_to_blob(map_name)?;
-            let map_id = (map_owner, map_name);
-            ENCRYPTED_MAPS.with_borrow(|encrypted_maps| {
-                encrypted_maps.as_ref().unwrap().get_encrypted_value(
-                    ::ic_cdk::api::msg_caller(),
-                    map_id,
-                    __encrypted_maps_bytebuf_to_blob(map_key)?,
-                )
-            })
-        }
-
-        #[::ic_cdk::update]
-        fn remove_map_values(
-            map_owner: __EmPrincipal,
-            map_name: __EmByteBuf,
-        ) -> Result<Vec<__EmEncryptedMapValue>, String> {
-            let map_name = __encrypted_maps_bytebuf_to_blob(map_name)?;
-            let map_id = (map_owner, map_name);
-            let result = ENCRYPTED_MAPS.with_borrow_mut(|encrypted_maps| {
-                encrypted_maps
-                    .as_mut()
-                    .unwrap()
-                    .remove_map_values(::ic_cdk::api::msg_caller(), map_id)
-            });
-            result.map(|removed| {
-                removed
-                    .into_iter()
-                    .map(|key| __EmByteBuf::from(key.as_ref().to_vec()))
-                    .collect()
-            })
-        }
-
-        #[::ic_cdk::query]
         fn get_owned_non_empty_map_names() -> Vec<__EmByteBuf> {
             ENCRYPTED_MAPS.with_borrow(|encrypted_maps| {
                 encrypted_maps
@@ -257,42 +353,6 @@ macro_rules! export_encrypted_maps_canister {
                     .into_iter()
                     .map(|map_name| __EmByteBuf::from(map_name.as_slice().to_vec()))
                     .collect()
-            })
-        }
-
-        #[::ic_cdk::update]
-        fn insert_encrypted_value(
-            map_owner: __EmPrincipal,
-            map_name: __EmByteBuf,
-            map_key: __EmByteBuf,
-            value: __EmEncryptedMapValue,
-        ) -> Result<Option<__EmEncryptedMapValue>, String> {
-            let map_name = __encrypted_maps_bytebuf_to_blob(map_name)?;
-            let map_id = (map_owner, map_name);
-            ENCRYPTED_MAPS.with_borrow_mut(|encrypted_maps| {
-                encrypted_maps.as_mut().unwrap().insert_encrypted_value(
-                    ::ic_cdk::api::msg_caller(),
-                    map_id,
-                    __encrypted_maps_bytebuf_to_blob(map_key)?,
-                    value,
-                )
-            })
-        }
-
-        #[::ic_cdk::update]
-        fn remove_encrypted_value(
-            map_owner: __EmPrincipal,
-            map_name: __EmByteBuf,
-            map_key: __EmByteBuf,
-        ) -> Result<Option<__EmEncryptedMapValue>, String> {
-            let map_name = __encrypted_maps_bytebuf_to_blob(map_name)?;
-            let map_id = (map_owner, map_name);
-            ENCRYPTED_MAPS.with_borrow_mut(|encrypted_maps| {
-                encrypted_maps.as_mut().unwrap().remove_encrypted_value(
-                    ::ic_cdk::api::msg_caller(),
-                    map_id,
-                    __encrypted_maps_bytebuf_to_blob(map_key)?,
-                )
             })
         }
 
@@ -376,6 +436,144 @@ macro_rules! export_encrypted_maps_canister {
                     ::ic_cdk::api::msg_caller(),
                     map_id,
                     user,
+                )
+            })
+        }
+    };
+}
+
+/// The value data-plane endpoints (read/write encrypted map values). Omitted by
+/// the `custom_value_endpoints` form. Not a public API.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __export_encrypted_maps_value_endpoints {
+    () => {
+        #[::ic_cdk::query]
+        fn get_encrypted_values_for_map(
+            map_owner: __EmPrincipal,
+            map_name: __EmByteBuf,
+        ) -> Result<Vec<(__EmByteBuf, __EmEncryptedMapValue)>, String> {
+            let map_name = __encrypted_maps_bytebuf_to_blob(map_name)?;
+            let map_id = (map_owner, map_name);
+            let result = ENCRYPTED_MAPS.with_borrow(|encrypted_maps| {
+                encrypted_maps
+                    .as_ref()
+                    .unwrap()
+                    .get_encrypted_values_for_map(::ic_cdk::api::msg_caller(), map_id)
+            });
+            result.map(|map_values| {
+                map_values
+                    .into_iter()
+                    .map(|(key, value)| (__EmByteBuf::from(key.as_slice().to_vec()), value))
+                    .collect()
+            })
+        }
+
+        #[::ic_cdk::query]
+        fn get_all_accessible_encrypted_values() -> Vec<(
+            (__EmPrincipal, __EmByteBuf),
+            Vec<(__EmByteBuf, __EmEncryptedMapValue)>,
+        )> {
+            ENCRYPTED_MAPS
+                .with_borrow(|encrypted_maps| {
+                    encrypted_maps
+                        .as_ref()
+                        .unwrap()
+                        .get_all_accessible_encrypted_values(::ic_cdk::api::msg_caller())
+                })
+                .into_iter()
+                .map(|((owner, map_name), encrypted_values)| {
+                    (
+                        (owner, __EmByteBuf::from(map_name.as_ref().to_vec())),
+                        encrypted_values
+                            .into_iter()
+                            .map(|(key, value)| (__EmByteBuf::from(key.as_ref().to_vec()), value))
+                            .collect(),
+                    )
+                })
+                .collect()
+        }
+
+        #[::ic_cdk::query]
+        fn get_all_accessible_encrypted_maps() -> Vec<__EmEncryptedMapData<__EmAccessRights>> {
+            ENCRYPTED_MAPS.with_borrow(|encrypted_maps| {
+                encrypted_maps
+                    .as_ref()
+                    .unwrap()
+                    .get_all_accessible_encrypted_maps(::ic_cdk::api::msg_caller())
+            })
+        }
+
+        #[::ic_cdk::query]
+        fn get_encrypted_value(
+            map_owner: __EmPrincipal,
+            map_name: __EmByteBuf,
+            map_key: __EmByteBuf,
+        ) -> Result<Option<__EmEncryptedMapValue>, String> {
+            let map_name = __encrypted_maps_bytebuf_to_blob(map_name)?;
+            let map_id = (map_owner, map_name);
+            ENCRYPTED_MAPS.with_borrow(|encrypted_maps| {
+                encrypted_maps.as_ref().unwrap().get_encrypted_value(
+                    ::ic_cdk::api::msg_caller(),
+                    map_id,
+                    __encrypted_maps_bytebuf_to_blob(map_key)?,
+                )
+            })
+        }
+
+        #[::ic_cdk::update]
+        fn remove_map_values(
+            map_owner: __EmPrincipal,
+            map_name: __EmByteBuf,
+        ) -> Result<Vec<__EmEncryptedMapValue>, String> {
+            let map_name = __encrypted_maps_bytebuf_to_blob(map_name)?;
+            let map_id = (map_owner, map_name);
+            let result = ENCRYPTED_MAPS.with_borrow_mut(|encrypted_maps| {
+                encrypted_maps
+                    .as_mut()
+                    .unwrap()
+                    .remove_map_values(::ic_cdk::api::msg_caller(), map_id)
+            });
+            result.map(|removed| {
+                removed
+                    .into_iter()
+                    .map(|key| __EmByteBuf::from(key.as_ref().to_vec()))
+                    .collect()
+            })
+        }
+
+        #[::ic_cdk::update]
+        fn insert_encrypted_value(
+            map_owner: __EmPrincipal,
+            map_name: __EmByteBuf,
+            map_key: __EmByteBuf,
+            value: __EmEncryptedMapValue,
+        ) -> Result<Option<__EmEncryptedMapValue>, String> {
+            let map_name = __encrypted_maps_bytebuf_to_blob(map_name)?;
+            let map_id = (map_owner, map_name);
+            ENCRYPTED_MAPS.with_borrow_mut(|encrypted_maps| {
+                encrypted_maps.as_mut().unwrap().insert_encrypted_value(
+                    ::ic_cdk::api::msg_caller(),
+                    map_id,
+                    __encrypted_maps_bytebuf_to_blob(map_key)?,
+                    value,
+                )
+            })
+        }
+
+        #[::ic_cdk::update]
+        fn remove_encrypted_value(
+            map_owner: __EmPrincipal,
+            map_name: __EmByteBuf,
+            map_key: __EmByteBuf,
+        ) -> Result<Option<__EmEncryptedMapValue>, String> {
+            let map_name = __encrypted_maps_bytebuf_to_blob(map_name)?;
+            let map_id = (map_owner, map_name);
+            ENCRYPTED_MAPS.with_borrow_mut(|encrypted_maps| {
+                encrypted_maps.as_mut().unwrap().remove_encrypted_value(
+                    ::ic_cdk::api::msg_caller(),
+                    map_id,
+                    __encrypted_maps_bytebuf_to_blob(map_key)?,
                 )
             })
         }

--- a/backend/rs/ic_vetkeys/src/encrypted_maps/canister.rs
+++ b/backend/rs/ic_vetkeys/src/encrypted_maps/canister.rs
@@ -88,37 +88,20 @@
 ///
 /// ```ignore
 /// // Generates: #[init]/#[post_upgrade], the stable EncryptedMaps state, the
-/// // control-plane endpoints, and the `with_encrypted_maps`/`_mut` accessors.
-/// // Does NOT generate any value read/write endpoints.
+/// // control-plane endpoints, and the `with_encrypted_maps`/`_mut` accessors —
+/// // but no value read/write endpoints. Write your own against the accessor:
+/// //   with_encrypted_maps_mut(|em| em.insert_encrypted_value(caller, id, key, value))
 /// ic_vetkeys::export_encrypted_maps_canister!(
 ///     "my_app_domain_separator",
 ///     [memory(0), memory(1), memory(2), memory(3)],
 ///     custom_value_endpoints,
 /// );
-///
-/// thread_local! {
-///     // Adopter-owned side-state, in the same MemoryManager under another id.
-///     static METADATA: RefCell<MetadataMap> =
-///         RefCell::new(ic_stable_structures::StableBTreeMap::init(memory(4)));
-/// }
-///
-/// #[ic_cdk::update]
-/// fn insert_encrypted_value_with_metadata(
-///     map_owner: Principal, map_name: ByteBuf, map_key: ByteBuf,
-///     value: EncryptedMapValue, /* ...app fields... */
-/// ) -> Result<Option<EncryptedMapValue>, String> {
-///     // Reuse the library's crypto + access control via the accessor:
-///     let previous = with_encrypted_maps_mut(|em| em.insert_encrypted_value(
-///         ic_cdk::api::msg_caller(),
-///         (map_owner, blob(map_name)?),
-///         blob(map_key)?,
-///         value,
-///     ))?;
-///     // ...maintain the linked METADATA row in the same call...
-///     Ok(previous)
-/// }
 /// ic_cdk::export_candid!();
 /// ```
+///
+/// For a complete, compile-tested example see the `ic-vetkeys-encrypted-maps-custom-canister`
+/// reference canister in this repository, and `password_manager_with_metadata` in
+/// [dfinity/examples](https://github.com/dfinity/examples) for the full linked-metadata pattern.
 ///
 /// ## Which endpoints are omitted, and why
 ///

--- a/backend/rs/ic_vetkeys/src/encrypted_maps/canister.rs
+++ b/backend/rs/ic_vetkeys/src/encrypted_maps/canister.rs
@@ -36,14 +36,18 @@
 /// other memory ids.
 ///
 /// The `#[init]` takes the vetKD key name (e.g. `"test_key_1"` locally,
-/// `"key_1"` on mainnet). The macro injects the canister entry points into the
-/// invoking module — the `#[init]`/`#[post_upgrade]` and the `#[query]`/
-/// `#[update]` endpoints (plus a private thread-local and helpers) — but it does
-/// **not** bind any common names in your scope (all library types are imported
-/// under unique aliases), so it won't clash with your own `use` imports. It
-/// does not emit the Candid interface, because `ic_cdk::export_candid!()`
-/// cannot be expanded from within another macro — call it yourself after the
-/// macro.
+/// `"key_1"` on mainnet). The macro injects items into the invoking module: the
+/// `#[init]`/`#[post_upgrade]`, the `#[query]`/`#[update]` endpoints, and the
+/// [`with_encrypted_maps`]/[`with_encrypted_maps_mut`] accessors (plus a private
+/// thread-local and helpers). Library *types* are imported under unique aliases,
+/// so they never clash with your own `use` imports; but the endpoint functions
+/// and the two accessors are ordinary items in your module — don't define items
+/// of your own with those names. It does not emit the Candid interface, because
+/// `ic_cdk::export_candid!()` cannot be expanded from within another macro —
+/// call it yourself after the macro.
+///
+/// [`with_encrypted_maps`]: #accessing-the-encryptedmaps-instance
+/// [`with_encrypted_maps_mut`]: #accessing-the-encryptedmaps-instance
 ///
 /// # Full canister
 ///
@@ -286,24 +290,34 @@ macro_rules! __export_encrypted_maps_common {
         /// Run `f` with a shared reference to the initialized `EncryptedMaps`.
         ///
         /// For hand-written endpoints that reuse the library's vetKD / crypto /
-        /// access-control logic. Traps if called before `#[init]` (it never is —
+        /// access-control logic. `pub(crate)` so it is reachable from submodules
+        /// of the invoking crate. Traps if called before `#[init]` (it never is —
         /// the state is set up in `#[init]`/`#[post_upgrade]`).
         #[allow(dead_code)]
-        fn with_encrypted_maps<__EmR>(
+        pub(crate) fn with_encrypted_maps<__EmR>(
             f: impl FnOnce(&__EmEncryptedMaps<__EmAccessRights>) -> __EmR,
         ) -> __EmR {
-            ENCRYPTED_MAPS.with_borrow(|encrypted_maps| f(encrypted_maps.as_ref().unwrap()))
+            ENCRYPTED_MAPS.with_borrow(|encrypted_maps| {
+                f(encrypted_maps
+                    .as_ref()
+                    .expect("EncryptedMaps is not initialized (called before #[init]/#[post_upgrade])"))
+            })
         }
 
         /// Run `f` with a mutable reference to the initialized `EncryptedMaps`.
         ///
         /// Gives access to the raw value mutators; when wrapping them, keep any
-        /// linked side-state updated in the same endpoint call.
+        /// linked side-state updated in the same endpoint call. `pub(crate)` so
+        /// it is reachable from submodules of the invoking crate.
         #[allow(dead_code)]
-        fn with_encrypted_maps_mut<__EmR>(
+        pub(crate) fn with_encrypted_maps_mut<__EmR>(
             f: impl FnOnce(&mut __EmEncryptedMaps<__EmAccessRights>) -> __EmR,
         ) -> __EmR {
-            ENCRYPTED_MAPS.with_borrow_mut(|encrypted_maps| f(encrypted_maps.as_mut().unwrap()))
+            ENCRYPTED_MAPS.with_borrow_mut(|encrypted_maps| {
+                f(encrypted_maps
+                    .as_mut()
+                    .expect("EncryptedMaps is not initialized (called before #[init]/#[post_upgrade])"))
+            })
         }
     };
 }


### PR DESCRIPTION
Implements the Rust half of #423.

## What changes
`export_encrypted_maps_canister!` gains a second form:

```rust
// Full canister (unchanged — the 95% case):
ic_vetkeys::export_encrypted_maps_canister!("app", [memory(0), memory(1), memory(2), memory(3)]);

// New: control-plane + state + lifecycle + accessors, but NO value endpoints:
ic_vetkeys::export_encrypted_maps_canister!("app", [memory(0), memory(1), memory(2), memory(3)], custom_value_endpoints);
```

The `custom_value_endpoints` form generates the 8 control-plane endpoints, the stable state, `#[init]`/`#[post_upgrade]`, and two accessors — but **omits the 7 value read/write endpoints**. Both forms now emit:

```rust
fn with_encrypted_maps<R>(f: impl FnOnce(&EncryptedMaps<AccessRights>) -> R) -> R;
fn with_encrypted_maps_mut<R>(f: impl FnOnce(&mut EncryptedMaps<AccessRights>) -> R) -> R;
```

## Why
The generators are all-or-nothing today, so the common "wrap-and-extend" pattern — a canister that stores something linked to each value (e.g. a metadata row per entry) and must own the value endpoints to keep the two stores consistent — can't use the macro at all and hand-writes ~200 lines. `custom_value_endpoints` lets it generate the safe control-plane passthroughs and write only its custom value endpoints, reusing the library's vetKD/crypto/ACL via the accessors.

**Coarse (whole value data-plane) instead of a fine-grained `exclude: [list]`, deliberately** — it's one unmissable decision rather than a list you can under-specify. (The `exclude` list in #423's own body proved the trap: it listed 6 names and omitted `get_all_accessible_encrypted_maps`, which returns raw values via `EncryptedMapData.keyvals` — a leak.) It's also forward-safe: a value endpoint added to the library later is hidden from adopters automatically, whereas a baked-in exclude list would silently re-expose it. Full rationale and the alternatives considered are in the [#423 thread](https://github.com/dfinity/vetkeys/issues/423).

## How it simplifies adoption (`password_manager_with_metadata`)
Today that example (~250 lines) forgoes the generator and hand-writes 11 endpoints; ~120–130 of those lines are the 8 passthroughs + init/post_upgrade/state setup that the generator already produces. With `custom_value_endpoints` those collapse to a 3-line macro call and only the 3 genuine `*_with_metadata` endpoints stay hand-written — roughly halving the file, keeping the passthroughs frontend-compatible by construction, and never emitting the raw value mutators (so the value↔metadata invariant can't be bypassed at the boundary).

## Which endpoints, and the rationale
- **Omitted (value data-plane, 7):** writes `insert_encrypted_value`, `remove_encrypted_value`, `remove_map_values`; reads `get_encrypted_value`, `get_encrypted_values_for_map`, `get_all_accessible_encrypted_values`, `get_all_accessible_encrypted_maps`.
- Only the **3 writes** can break an adopter invariant (correctness). The **4 reads** are dropped for API-surface hygiene (no metadata-less value view beside the wrapped one). Documented in the macro rustdoc.
- **Kept (control-plane, 8):** none read or write values — `set_user_rights`/`remove_user` touch only the ACL, no value cascade — so they're always safe to emit.

## Interface / release impact
- The **full** form is unchanged. Endpoints are factored into inner macros, but `export_candid!` emits methods **alphabetically**, so the generated `.did` is identical — verified by diffing the extracted candid (method set identical) and by interface-sync regenerating declarations from the committed `.did` (untouched). **No frontend files or `.did` change; no frontend release.**
- Additive/minor change. Recorded under an **Unreleased** changelog heading; the version number is assigned at release time (no `Cargo.toml` bump in this PR).

## Docs
- **Macro rustdoc** documents both forms, the omitted set with the write=correctness / read=hygiene rationale, the accessors, a metadata example, and the escape hatch if a write-only-wrap-keeping-reads need appears.
- **Crate README** (the docs.rs landing page) gains a "Ready-made EncryptedMaps canister" section pointing to the macro and both forms — it previously didn't mention the generator at all.
- **Reference-canister READMEs**: the new custom canister gets its own README, cross-linked from the full reference canister's README.

## Implementation & verification
- Factored the macro into `__export_encrypted_maps_{common,control_plane_endpoints,value_endpoints}!` helpers composed by the two public arms.
- Added a reference canister `ic-vetkeys-encrypted-maps-custom-canister` that dogfoods the new form + accessors; wired into the CI wasm build.
- Verified: full-form `.did` identical; encrypted_maps reference tests 19/19; doctests pass and `cargo doc -D warnings` clean; `cargo fmt --check` and CI-style `cargo clippy -- -Dwarnings` clean; custom canister builds host + wasm.

Motoko gets the mirrored layered mixin in a separate PR.