### PR TITLE
chore: use "app" instead of "dapp" throughout the repo

### DIFF
--- a/backend/mo/canisters/ic_vetkeys_encrypted_maps_canister/README.md
+++ b/backend/mo/canisters/ic_vetkeys_encrypted_maps_canister/README.md
@@ -4,4 +4,4 @@ The canister implemented in this folder directly exposes the methods of the encr
 This is useful for:
 
 1. running canister tests
-2. implementing dapps that only require encrypted maps
+2. implementing apps that only require encrypted maps

--- a/backend/mo/canisters/ic_vetkeys_encrypted_maps_canister/src/Main.mo
+++ b/backend/mo/canisters/ic_vetkeys_encrypted_maps_canister/src/Main.mo
@@ -5,5 +5,5 @@ import EncryptedMapsCanister "mo:ic-vetkeys/encrypted_maps/Canister";
 // library mixin, which guarantees the exposed Candid matches what the
 // `@icp-sdk/vetkeys` frontend expects.
 persistent actor class (keyName : Text) {
-    include EncryptedMapsCanister(keyName, "password_manager_example_dapp");
+    include EncryptedMapsCanister(keyName, "password_manager_example_app");
 };

--- a/backend/mo/canisters/ic_vetkeys_manager_canister/README.md
+++ b/backend/mo/canisters/ic_vetkeys_manager_canister/README.md
@@ -4,4 +4,4 @@ The canister implemented in this folder directly exposes the methods of the key 
 This is useful for:
 
 1. running canister tests
-2. implementing dapps that only require a key manager
+2. implementing apps that only require a key manager

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/README.md
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/README.md
@@ -4,6 +4,6 @@ The canister implemented in this folder directly exposes the methods of the encr
 This is useful for:
 
 1. running canister tests
-2. implementing dapps that only require encrypted maps
+2. implementing apps that only require encrypted maps
 
-It uses the full form of the [`export_encrypted_maps_canister!`](https://docs.rs/ic-vetkeys/latest/ic_vetkeys/macro.export_encrypted_maps_canister.html) macro. If your dapp keeps state linked to each value and needs to provide its own value endpoints, see [`ic-vetkeys-encrypted-maps-custom-canister`](../ic_vetkeys_encrypted_maps_custom_canister) and the macro's `custom_value_endpoints` form.
+It uses the full form of the [`export_encrypted_maps_canister!`](https://docs.rs/ic-vetkeys/latest/ic_vetkeys/macro.export_encrypted_maps_canister.html) macro. If your app keeps state linked to each value and needs to provide its own value endpoints, see [`ic-vetkeys-encrypted-maps-custom-canister`](../ic_vetkeys_encrypted_maps_custom_canister) and the macro's `custom_value_endpoints` form.

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/src/lib.rs
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_canister/src/lib.rs
@@ -19,7 +19,7 @@ fn memory(id: u8) -> Memory {
 }
 
 ic_vetkeys::export_encrypted_maps_canister!(
-    "encrypted_maps_dapp",
+    "encrypted_maps_app",
     [memory(0), memory(1), memory(2), memory(3)],
 );
 

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_custom_canister/README.md
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_custom_canister/README.md
@@ -10,7 +10,7 @@ control-plane endpoints (vetKD keys, access control, map-name enumeration) plus
 the state, lifecycle hooks, and the `with_encrypted_maps`/`with_encrypted_maps_mut`
 accessors, and provides its own value read/write endpoints.
 
-This is the pattern for dapps that keep state linked to each encrypted value
+This is the pattern for apps that keep state linked to each encrypted value
 (e.g. a metadata row per entry) and therefore must own the value endpoints to
 keep the two stores consistent — see `password_manager_with_metadata` in
 [dfinity/examples](https://github.com/dfinity/examples). The endpoints here are

--- a/backend/rs/canisters/ic_vetkeys_encrypted_maps_custom_canister/src/lib.rs
+++ b/backend/rs/canisters/ic_vetkeys_encrypted_maps_custom_canister/src/lib.rs
@@ -29,7 +29,7 @@ fn memory(id: u8) -> Memory {
 
 // Control plane + state + lifecycle + accessors; no value endpoints.
 ic_vetkeys::export_encrypted_maps_canister!(
-    "encrypted_maps_custom_dapp",
+    "encrypted_maps_custom_app",
     [memory(0), memory(1), memory(2), memory(3)],
     custom_value_endpoints,
 );

--- a/backend/rs/canisters/ic_vetkeys_manager_canister/README.md
+++ b/backend/rs/canisters/ic_vetkeys_manager_canister/README.md
@@ -4,4 +4,4 @@ The canister implemented in this folder directly exposes the methods of the key 
 This is useful for:
 
 1. running canister tests
-2. implementing dapps that only require a key manager
+2. implementing apps that only require a key manager

--- a/backend/rs/canisters/ic_vetkeys_manager_canister/src/lib.rs
+++ b/backend/rs/canisters/ic_vetkeys_manager_canister/src/lib.rs
@@ -48,7 +48,7 @@ fn setup(key_name: String) {
     };
     KEY_MANAGER.with_borrow_mut(|km| {
         km.replace(KeyManager::init(
-            "key_manager_dapp",
+            "key_manager_app",
             key_id,
             id_to_memory(0),
             id_to_memory(1),

--- a/backend/rs/ic_vetkeys/src/encrypted_maps/mod.rs
+++ b/backend/rs/ic_vetkeys/src/encrypted_maps/mod.rs
@@ -96,7 +96,7 @@ impl<T: AccessControl> EncryptedMaps<T> {
     ///     };
     ///     ENCRYPTED_MAPS.with_borrow_mut(|encrypted_maps| {
     ///         encrypted_maps.replace(EncryptedMaps::init(
-    ///         "my encrypted maps dapp",
+    ///         "my encrypted maps app",
     ///         key_id,
     ///         id_to_memory(0),
     ///         id_to_memory(1),

--- a/backend/rs/ic_vetkeys/src/key_manager/mod.rs
+++ b/backend/rs/ic_vetkeys/src/key_manager/mod.rs
@@ -93,7 +93,7 @@ impl<T: AccessControl> KeyManager<T> {
     ///     };
     ///     KEY_MANAGER.with_borrow_mut(|km| {
     ///         km.replace(KeyManager::init(
-    ///             "key_manager_dapp",
+    ///             "key_manager_app",
     ///             key_id,
     ///             id_to_memory(0),
     ///             id_to_memory(1),


### PR DESCRIPTION
Replaces the term **dapp** with **app** everywhere it appears in the repo.

- Prose in the reference-canister READMEs ("dapps that only require…" → "apps…", "your dapp" → "your app").
- Doc examples in the `ic-vetkeys` crate (`key_manager` / `encrypted_maps` `init` examples).
- Example **domain-separator** strings in the reference canisters: `encrypted_maps_dapp` → `encrypted_maps_app`, `encrypted_maps_custom_dapp` → `encrypted_maps_custom_app`, `key_manager_dapp` → `key_manager_app`, `password_manager_example_dapp` → `password_manager_example_app`.

Domain separators affect vetKD key derivation only for an already-deployed instance; these are reference/example canisters, and no test asserts the separator (verification uses `key_id_to_vetkd_input(owner, name)`, not the separator), so the rename is behavior-neutral for the repo.

**Verified:** encrypted_maps canister tests 19/19, `ic-vetkeys` doctests pass, all reference canisters build (Rust wasm + Motoko).

Note: the Motoko `EncryptedMapsControlPlaneCanister` work in #425 carries its own `*_dapp` strings on that branch; they're renamed there too so the repo stays `dapp`-free once both land.